### PR TITLE
[TEST] 구글 id토큰 발급 api 요청 테스트 작성

### DIFF
--- a/backend/src/main/java/agilementor/member/service/AuthClientService.java
+++ b/backend/src/main/java/agilementor/member/service/AuthClientService.java
@@ -19,10 +19,10 @@ public class AuthClientService {
     private final RestClient restClient;
 
     public AuthClientService(GoogleClientProperties clientProperties,
-        GoogleProviderProperties providerProperties) {
+        GoogleProviderProperties providerProperties, RestClient.Builder restClientBuilder) {
         this.clientProperties = clientProperties;
         this.providerProperties = providerProperties;
-        restClient = RestClient.builder().build();
+        restClient = restClientBuilder.build();
     }
 
     public String getAuthUrl() {

--- a/backend/src/test/java/agilementor/member/service/AuthClientServiceTest.java
+++ b/backend/src/test/java/agilementor/member/service/AuthClientServiceTest.java
@@ -1,9 +1,13 @@
 package agilementor.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import agilementor.member.properties.GoogleClientProperties;
@@ -11,16 +15,15 @@ import agilementor.member.properties.GoogleProviderProperties;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.test.web.client.match.MockRestRequestMatchers;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponents;
@@ -35,11 +38,11 @@ class AuthClientServiceTest {
     @Mock
     private GoogleProviderProperties providerProperties;
 
-    @InjectMocks
     private AuthClientService authClientService;
 
-    private MockRestServiceServer server = MockRestServiceServer
-        .bindTo(RestClient.builder()).build();
+    private RestClient.Builder restClientBuilder = RestClient.builder();
+
+    private MockRestServiceServer server;
 
     private final String CLIENT_ID = "CLIENT_ID";
     private final String CLIENT_SECRET = "CLIENT_SECRET";
@@ -48,6 +51,13 @@ class AuthClientServiceTest {
     private final String AUTHORIZATION_URI = "https://authorization-uri.com";
     private final String TOKEN_URI = "https://token-uri.com";
     private final String CODE = "authorizationCode";
+
+    @BeforeEach
+    void setup() {
+        server = MockRestServiceServer.bindTo(restClientBuilder).build();
+        authClientService = new AuthClientService(clientProperties, providerProperties,
+            restClientBuilder);
+    }
 
     @Test
     @DisplayName("구글 인증 url을 만들 수 있다.")
@@ -71,4 +81,70 @@ class AuthClientServiceTest {
         assertThat(Set.of(queryParams.get("scope").getFirst().split("%20"))).isEqualTo(SCOPE);
         assertThat(queryParams.get("redirect_uri").getFirst()).isEqualTo(REDIRECT_URI);
     }
+
+    @Test
+    @DisplayName("구글 id토큰을 발급받을 수 있다.")
+    void requestIdToken() {
+        // given
+        given(clientProperties.clientId()).willReturn(CLIENT_ID);
+        given(clientProperties.clientSecret()).willReturn(CLIENT_SECRET);
+        given(clientProperties.redirectUri()).willReturn(REDIRECT_URI);
+        given(providerProperties.tokenUri()).willReturn(TOKEN_URI);
+
+        Map<String, String> expectedBody = Map.of("client_id", CLIENT_ID, "client_secret",
+            CLIENT_SECRET, "redirect_uri", REDIRECT_URI, "code", CODE);
+        String idToken = "id.token";
+        String expectedResult = "{\"id_token\": \"" + idToken + "\"}";
+
+        server.expect(requestTo(TOKEN_URI))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(content().formDataContains(expectedBody))
+            .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+        // when
+        String actualIdToken = authClientService.requestIdToken(CODE);
+
+        // then
+        assertThat(actualIdToken).isEqualTo(idToken);
+    }
+
+    @Test
+    @DisplayName("id토큰 발급요청 결과 4xx 에러일 경우 IllegalArgumentException을 발생시킨다.")
+    void requestIdTokenResult4xxError() {
+        // given
+        given(clientProperties.clientId()).willReturn(CLIENT_ID);
+        given(clientProperties.clientSecret()).willReturn(CLIENT_SECRET);
+        given(clientProperties.redirectUri()).willReturn(REDIRECT_URI);
+        given(providerProperties.tokenUri()).willReturn(TOKEN_URI);
+
+        server.expect(requestTo(TOKEN_URI))
+            .andExpect(method(HttpMethod.POST))
+            .andRespond(withBadRequest());
+
+        // when
+        // then
+        assertThatThrownBy(() -> authClientService.requestIdToken(CODE))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("id토큰 발급요청 결과 5xx 에러일 경우 RuntimeException을 발생시킨다.")
+    void requestIdTokenResult5xxError() {
+        // given
+        given(clientProperties.clientId()).willReturn(CLIENT_ID);
+        given(clientProperties.clientSecret()).willReturn(CLIENT_SECRET);
+        given(clientProperties.redirectUri()).willReturn(REDIRECT_URI);
+        given(providerProperties.tokenUri()).willReturn(TOKEN_URI);
+
+        server.expect(requestTo(TOKEN_URI))
+            .andExpect(method(HttpMethod.POST))
+            .andRespond(withServerError());
+
+        // when
+        // then
+        assertThatThrownBy(() -> authClientService.requestIdToken(CODE))
+            .isInstanceOf(RuntimeException.class);
+    }
+
+
 }


### PR DESCRIPTION
## 📌 관련 이슈
#13  [REFACTOR, TEST] 구글 ID토큰 발급 API 호출 기능 테스트 작성

## ✨ PR 내용
- 테스트를 위해 AuthClientService의 restClient를 스프링이 주입해준 RestClient.Builder를 이용해서 생성하도록 수정
- 구글 ID토큰 발급 API 호출 기능 테스트 작성