### PR TITLE
[FEAT] 번다운 차트 페이지 구현 

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "^6.1.6",
     "@mui/material": "^6.1.6",
+    "@mui/x-charts": "^7.22.2",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/frontend/src/components/common/AgileNotesList/index.jsx
+++ b/frontend/src/components/common/AgileNotesList/index.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Typography, List, ListItem, ListItemText } from '@mui/material';
+import CircleIcon from '@mui/icons-material/Circle';
+
+const agileNotes = [
+  { id: 1, title: '효율적으로 회의하는 방법' },
+  { id: 2, title: '애자일 방법론이란?' },
+  { id: 3, title: '플래닝 포커란?' },
+  { id: 4, title: '스프린트와 백로그에 대해..' },
+];
+
+const AgileNotesList = () => (
+  <List>
+    {agileNotes.map((note) => (
+      <ListItem
+        key={note.id}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          cursor: 'pointer',
+          '&:hover': {
+            backgroundColor: '#f0f0f0',
+          },
+        }}
+        onClick={() => {}}
+      >
+        <CircleIcon sx={{ color: '#356B60', fontSize: '0.5rem', mr: 1 }} />
+        <ListItemText
+          primary={
+            <Typography sx={{ fontSize: '1rem', color: '#333' }}>
+              {note.title}
+            </Typography>
+          }
+        />
+      </ListItem>
+    ))}
+  </List>
+);
+
+export default AgileNotesList;

--- a/frontend/src/components/common/BurndownChart/index.jsx
+++ b/frontend/src/components/common/BurndownChart/index.jsx
@@ -19,7 +19,7 @@ const BurndownChart = () => {
     <Box
       sx={{
         height: '65vh',
-        width: '70vw',
+        width: '71vw',
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',

--- a/frontend/src/components/common/BurndownChart/index.jsx
+++ b/frontend/src/components/common/BurndownChart/index.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Box, Paper, Typography } from '@mui/material';
+import { LineChart } from '@mui/x-charts';
+import mockSprints from '../../../mocks/mockSprints';
+
+const BurndownChart = () => {
+  const totalTasks = 50;
+  const pData = mockSprints.map((sprint) => sprint.completed_tasks_count);
+  const xLabels = mockSprints.map((sprint) => sprint.end_date);
+
+  const remainingData = [];
+  let cumulativeCompleted = 0;
+  pData.forEach((completed) => {
+    cumulativeCompleted += completed;
+    remainingData.push(totalTasks - cumulativeCompleted);
+  });
+
+  return (
+    <Box
+      sx={{
+        height: '65vh',
+        width: '70vw',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <Paper
+        sx={{
+          height: '100%',
+          width: '100%',
+          borderRadius: 3,
+          padding: 2,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+        elevation={3}
+      >
+        <Typography variant="h6" sx={{ fontSize: '35px' }}>
+            Burndown Chart
+        </Typography>
+        <Box 
+          sx={{ 
+            height: '90%', 
+            width: '90%', 
+            display: 'flex', 
+            justifyContent: 'center', 
+            alignItems: 'center' 
+          }}
+        >
+          <LineChart
+            width={1000}
+            height={450}
+            series={[
+              { data: pData, label: 'Completed Tasks' },
+              { data: remainingData, label: 'Remaining Tasks' },
+            ]}
+            xAxis={[{ scaleType: 'point', data: xLabels }]}
+            yAxis={[{ min: 0 }]}
+            slotProps={{
+              legend: {
+                itemGap: 20,
+              },
+            }}
+          />
+        </Box>
+      </Paper>
+    </Box>
+  );
+};
+
+export default BurndownChart;

--- a/frontend/src/components/common/ExternalLinkButtons/index.jsx
+++ b/frontend/src/components/common/ExternalLinkButtons/index.jsx
@@ -32,7 +32,7 @@ const images = [
   },
 ];
 
-const BUTTON_SIZE = 111;
+const BUTTON_SIZE = '11vh';
 
 const ImageButton = styled(ButtonBase)(({ isFirst, isLast }) => {
   let borderRadius = 0;

--- a/frontend/src/components/common/OngoingTasksList/index.jsx
+++ b/frontend/src/components/common/OngoingTasksList/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, Typography, IconButton, Divider } from '@mui/material';
-import InfoIcon from '@mui/icons-material/Info';
+import { Box, Typography, Divider } from '@mui/material';
+import CircleIcon from '@mui/icons-material/Circle';
 import mockBacklogs from '../../../mocks/mockBacklogs';
 
 const OngoingTasksList = ({ memberId }) => {
@@ -14,11 +14,8 @@ const OngoingTasksList = ({ memberId }) => {
   return (
     <Box>
       {projects.map((projectId, index) => (
-        <Box key={projectId} mb={1}>
+        <Box key={projectId} mb={1.5}>
           {index > 0 && <Divider sx={{ mb: 1 }} />}
-          <Typography variant="h6" sx={{ fontWeight: 'bold', fontSize:'1.1rem', color: '#333', mb: 1 }}>
-            Project Name: {projectId}
-          </Typography>
           {filteredBacklogs
             .filter((task) => task.project_id === projectId)
             .map((task) => (
@@ -27,14 +24,17 @@ const OngoingTasksList = ({ memberId }) => {
                 display="flex"
                 alignItems="center"
                 justifyContent="space-between"
-                mb={0}
+                mb={1}
               >
-                <Typography variant="body1" sx={{ fontSize: '1rem', color: '#333' }}>
-                  - {task.title}
+                <Box display="flex" alignItems="center">
+                  <CircleIcon sx={{ color: '#0eaaf9', fontSize: '0.5rem', mr: 1 }} />
+                  <Typography variant="body1" sx={{ fontSize: '1rem', color: '#333' }}>
+                    {task.title}
+                  </Typography>
+                </Box>
+                <Typography variant="body2" sx={{ color: '#666', fontSize: '0.8rem' }}>
+                  {projectId}
                 </Typography>
-                <IconButton sx={{ color: '#0eaaf9' }} aria-label="info">
-                  <InfoIcon fontSize="medium" />
-                </IconButton>
               </Box>
             ))}
         </Box>

--- a/frontend/src/components/common/ProjectList/index.jsx
+++ b/frontend/src/components/common/ProjectList/index.jsx
@@ -1,59 +1,81 @@
 import React from 'react';
-import styled from 'styled-components';
-import { Info, Edit, Delete } from '@mui/icons-material';
+import { Box, Typography, IconButton, Stack, ButtonBase } from '@mui/material';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
 import mockProjects from '../../../mocks/mockProjects';
 
-const ProjectList = () => (
-  <Container>
-    {mockProjects.map((project) => (
-      <ProjectItem key={project.id}>
-        <ProjectTitle>- {project.title}</ProjectTitle>
+const ICON_SIZE = 30;
+const FONT_SIZE = '0.8rem';
 
-        <IconGroup>
-          <IconButton color="#0eaaf9" aria-label="view">
-            <Info fontSize="small" />
+const ProjectList = () => (
+  <Box>
+    <Box display="flex" alignItems="center" mb={1}>
+      <IconButton
+        sx={{
+          width: ICON_SIZE,
+          height: ICON_SIZE,
+          backgroundColor: '#fff',
+          borderRadius: '8px',
+          border: '1px solid #ffc107',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#ffc107',
+          mr: 1,
+          '&:hover': {
+            backgroundColor: '#f0f0f0',
+          },
+        }}
+      >
+        <AddRoundedIcon fontSize="small" />
+      </IconButton>
+      <Typography variant="body1" sx={{ color: '#333', fontSize: FONT_SIZE }}>
+        새 프로젝트
+      </Typography>
+    </Box>
+
+    {mockProjects.map((project) => (
+      <Box
+        key={project.id}
+        display="flex"
+        alignItems="center"
+        justifyContent="space-between"
+        mb={0.5}
+      >
+        <Box display="flex" alignItems="center">
+          <Box
+            sx={{
+              width: ICON_SIZE,
+              height: ICON_SIZE,
+              backgroundColor: '#ffc107',
+              borderRadius: '8px',
+              mr: 1,
+            }}
+          />
+          <ButtonBase
+            sx={{
+              textAlign: 'left',
+              color: '#333',
+            }}
+          >
+            <Typography variant="body1" sx={{ fontSize: FONT_SIZE }}>
+              {project.title}
+            </Typography>
+          </ButtonBase>
+        </Box>
+
+        <Stack direction="row" spacing={0.5}>
+          <IconButton sx={{ color: '#9e9e9e' }} aria-label="edit">
+            <EditIcon fontSize="small" />
           </IconButton>
-          <IconButton color="#43a047" aria-label="edit">
-            <Edit fontSize="small" />
+          <IconButton sx={{ color: '#e53935' }} aria-label="delete">
+            <DeleteIcon fontSize="small" />
           </IconButton>
-          <IconButton color="#e53935" aria-label="delete">
-            <Delete fontSize="small" />
-          </IconButton>
-        </IconGroup>
-      </ProjectItem>
+        </Stack>
+      </Box>
     ))}
-  </Container>
+  </Box>
 );
 
 export default ProjectList;
-
-const Container = styled.div``;
-
-const ProjectItem = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 8px;
-`;
-
-const ProjectTitle = styled.span`
-  font-size: 1.2rem;
-  color: #333;
-`;
-
-const IconGroup = styled.div`
-  display: flex;
-  gap: 4px;
-`;
-
-const IconButton = styled.button`
-  background: none;
-  border: none;
-  color: ${(props) => props.color};
-  cursor: pointer;
-  padding: 4px;
-
-  &:hover {
-    opacity: 0.8;
-  }
-`;

--- a/frontend/src/components/features/Header.jsx
+++ b/frontend/src/components/features/Header.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 // eslint-disable-next-line import/no-unresolved
 import { Common } from '@styles/globalStyle';
 
-export const HEADER_HEIGHT = '76px';
+export const HEADER_HEIGHT = '9vh';
 
 const Header = () => (
   <HeaderContainer>
@@ -22,7 +22,7 @@ const HeaderContainer = styled.header`
   justify-content: flex-start;
   height: ${HEADER_HEIGHT};
   background-color: ${Common.colors.primary};
-  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0px 0.4vh 0.6vh rgba(0, 0, 0, 0.1); // 그림자 높이도 vh 단위로 변경
   z-index: 9999;
   position: relative;
 `;
@@ -30,18 +30,18 @@ const HeaderContainer = styled.header`
 const LogoContainer = styled.div`
   display: flex;
   align-items: center;
-  margin-left: 300px;
-  margin-right: 300px;
+  margin-left: 20vw; // 화면 너비에 맞춰 여백 설정
+  margin-right: 20vw;
 `;
 
 const LogoImage = styled.img`
-  width: 32px;
-  height: 32px;
-  margin-right: 10px;
+  width: 3vh; // vh 단위로 로고 크기 설정
+  height: 3vh;
+  margin-right: 1vh;
 `;
 
 const LogoText = styled.h1`
-  font-size: 20px;
+  font-size: 2vh; // vh 단위로 폰트 크기 설정
   font-weight: bold;
   color: #000;
 `;

--- a/frontend/src/mocks/mockProjects.js
+++ b/frontend/src/mocks/mockProjects.js
@@ -1,11 +1,10 @@
 const mockProjects = [
-    { id: 'project-1', title: 'Project A' },
-    { id: 'project-2', title: 'Project B' },
-    { id: 'project-3', title: 'Project C' },
-    { id: 'project-4', title: 'Project D' },
-    { id: 'project-5', title: 'Project E' },
-    { id: 'project-6', title: 'Project F' },
-  ];
-  
-  export default mockProjects;
-  
+  { id: 'project-1', title: '임시 프로젝트 1번' },
+  { id: 'project-2', title: '임시 프로젝트 2번' },
+  { id: 'project-3', title: '임시 프로젝트 3번' },
+  { id: 'project-4', title: '임시 프로젝트 4번' },
+  { id: 'project-5', title: '임시 프로젝트 5번' },
+  { id: 'project-6', title: '임시 프로젝트 6번' },
+];
+
+export default mockProjects;

--- a/frontend/src/mocks/mockSprints.js
+++ b/frontend/src/mocks/mockSprints.js
@@ -1,0 +1,12 @@
+const mockSprints = [
+    { sprint_id: 201, end_date: '2024-11-15', completed_tasks_count: 7 },
+    { sprint_id: 202, end_date: '2024-11-22', completed_tasks_count: 5 },
+    { sprint_id: 203, end_date: '2024-11-29', completed_tasks_count: 6 },
+    { sprint_id: 204, end_date: '2024-12-06', completed_tasks_count: 8 },
+    { sprint_id: 205, end_date: '2024-12-13', completed_tasks_count: 5 },
+    { sprint_id: 206, end_date: '2024-12-20', completed_tasks_count: 7 },
+    { sprint_id: 207, end_date: '2024-12-27', completed_tasks_count: 4 },
+    { sprint_id: 208, end_date: '2025-01-03', completed_tasks_count: 8 },
+  ];
+  
+  export default mockSprints;

--- a/frontend/src/pages/Burndown/index.jsx
+++ b/frontend/src/pages/Burndown/index.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import Header from '../../components/features/Header';
+import Sidebar from '../../components/features/SideBar';
+import BurndownChart from '../../components/common/BurndownChart';
+
+const BurndownPage = () => (
+  <Box sx={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
+    <Box sx={{ position: 'fixed', top: 0, width: '100%', zIndex: 1000 }}>
+      <Header />
+    </Box>
+
+    <Box
+      sx={{
+        position: 'fixed',
+        top: '9vh',
+        left: 0,
+        height: 'calc(100vh - 9vh)',
+        width: '23vw',
+        zIndex: 900,
+      }}
+    >
+      <Sidebar />
+    </Box>
+
+    <Box
+      component="main"
+      sx={{
+        position: 'fixed',
+        top: '9vh',
+        left: '23vw',
+        width: 'calc(100vw - 23vw)',
+        height: 'calc(100vh - 9vh)',
+        backgroundColor: '#FAFAFA',
+        padding: 4,
+        overflowY: 'auto',
+        color: '#333',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
+        <Box sx={{ maxWidth: '60%', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          <Typography variant="subtitle1">Project Name:</Typography>
+          <Typography
+            variant="h4"
+            sx={{
+              fontWeight: 'bold',
+              fontSize: '3.5rem',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            Project B
+          </Typography>
+        </Box>
+      </Box>
+
+      <BurndownChart />
+    </Box>
+  </Box>
+);
+
+export default BurndownPage;

--- a/frontend/src/pages/Dashboard/index.jsx
+++ b/frontend/src/pages/Dashboard/index.jsx
@@ -1,156 +1,121 @@
 import React from 'react';
-
-import { Typography, Divider } from '@mui/material';
-import styled from 'styled-components';
-// eslint-disable-next-line import/extensions
-import SideMenu from '../../components/features/SideBar';
+import { Box, Typography, Paper, Divider } from '@mui/material';
+import Header from '../../components/features/Header';
+import SideBar from '../../components/features/SideBar';
 import ExternalLinkButtons from '../../components/common/ExternalLinkButtons';
-// eslint-disable-next-line import/no-named-as-default
 import ProjectList from '../../components/common/ProjectList';
 import OngoingTasksList from '../../components/common/OngoingTasksList';
+import AgileNotesList from '../../components/common/AgileNotesList'
 
 const DashboardPage = () => (
-  <DashboardContainer>
-    <FixedSideMenu>
-      <SideMenu />
-    </FixedSideMenu>
+  <Box sx={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
+    <Box sx={{ position: 'fixed', top: 0, width: '100%', zIndex: 1000 }}>
+      <Header />
+    </Box>
 
-    <MainContent>
-      <HeaderContainer>
-        <ProjectInfo>
-          <Typography variant="subtitle1" sx={{ color: '#333' }}>
-            Project Name:
-          </Typography>
-          <Typography
-            variant="h4"
-            sx={{ fontWeight: 'bold', color: '#333', fontSize: '4rem' }}
-          >
-            Project B
-          </Typography>
-        </ProjectInfo>
-        <ExternalLinkContainer>
+    <Box sx={{ position: 'fixed', top: '9vh', left: 0, height: 'calc(100vh - 9vh)', zIndex: 900 }}>
+      <SideBar />
+    </Box>
+
+    <Box
+      component="main"
+      sx={{
+        position: 'fixed',
+        top: '9vh',
+        left: '23vw',
+        width: 'calc(100vw - 23vw)',
+        height: 'calc(100vh - 9vh)',
+        backgroundColor: '#FAFAFA',
+        padding: 4,
+        overflowY: 'auto',
+        overflowX: 'auto',
+      }}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', mb: 3 }}>
+        <Typography
+          variant="h4"
+          sx={{
+            fontWeight: 'bold',
+            color: '#333',
+            fontSize: '4vh',
+          }}
+        >
+          임지환님의 프로젝트
+        </Typography>
+        
+        <Box sx={{ mt: 2 }}>
           <ExternalLinkButtons />
-        </ExternalLinkContainer>
-      </HeaderContainer>
+        </Box>
+      </Box>
 
-      <ContentSection>
-        <StyledPaper>
-          <SectionHeader>
-            <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
-              My Projects
+      <Box sx={{ display: 'flex', gap: 3, mb: 3 }}>
+        <Paper
+          sx={{
+            flex: 1.5,
+            backgroundColor: '#fff',
+            borderRadius: 3,
+            height: '28vh',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+          }}
+        >
+          <Box sx={{ p: 2, pb: 0, position: 'sticky', top: 0, backgroundColor: '#fff', zIndex: 1 }}>
+            <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1 }}>
+              내 프로젝트
             </Typography>
             <Divider sx={{ mb: 0 }} />
-          </SectionHeader>
-          <SectionContent>
+          </Box>
+          <Box sx={{ p: 2, pt: 1, overflowY: 'auto', flexGrow: 1 }}>
             <ProjectList />
-          </SectionContent>
-        </StyledPaper>
+          </Box>
+        </Paper>
 
-        <StyledPaper flex={2}>
-          <SectionHeader>
-            <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
-              Ongoing Tasks
+        <Paper
+          sx={{
+            flex: 2.5,
+            backgroundColor: '#fff',
+            borderRadius: 3,
+            height: '28vh',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+          }}
+        >
+          <Box sx={{ p: 2, pb: 0, position: 'sticky', top: 0, backgroundColor: '#fff', zIndex: 1 }}>
+            <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1 }}>
+              진행중인 작업
             </Typography>
             <Divider sx={{ mb: 0 }} />
-          </SectionHeader>
-          <SectionContent>
+          </Box>
+          <Box sx={{ p: 2, pt: 1, overflowY: 'auto', flexGrow: 1 }}>
             <OngoingTasksList memberId={301} />
-          </SectionContent>
-        </StyledPaper>
-      </ContentSection>
+          </Box>
+        </Paper>
+      </Box>
 
-      <StyledPaper>
-        <SectionHeader>
-          <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
-            Agile Notes
+      <Paper
+        sx={{
+          backgroundColor: '#fff',
+          borderRadius: 3,
+          height: '30vh',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        <Box sx={{ p: 2, pb: 0, position: 'sticky', top: 0, backgroundColor: '#fff', zIndex: 1 }}>
+          <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1 }}>
+            애자일 학습하기
           </Typography>
           <Divider sx={{ mb: 0 }} />
-        </SectionHeader>
-        <SectionContent>
-          {[...Array(10)].map((_, index) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <Typography key={index}>
-              여기에 중요한 노트나 메모를 작성할 수 있습니다.
-            </Typography>
-          ))}
-        </SectionContent>
-      </StyledPaper>
-    </MainContent>
-  </DashboardContainer>
+        </Box>
+        <Box sx={{ p: 2, pt: 0, overflowY: 'auto', flexGrow: 1 }}>
+          <AgileNotesList />
+        </Box>
+      </Paper>
+    </Box>
+  </Box>
 );
 
 export default DashboardPage;
-
-const DashboardContainer = styled.div`
-  display: flex;
-  height: 100vh;
-  overflow: hidden;
-`;
-
-const FixedSideMenu = styled.div`
-  position: fixed;
-  top: 76px;
-  left: 0;
-  height: calc(100vh - 76px);
-  z-index: 900;
-`;
-
-const MainContent = styled.div`
-  position: fixed;
-  top: 76px;
-  left: 240px;
-  width: calc(100vw - 240px);
-  height: calc(100vh - 76px);
-  background-color: #f5f8ff;
-  padding: 32px;
-  overflow-y: auto;
-`;
-
-const HeaderContainer = styled.div`
-  display: flex;
-  align-items: center;
-  margin-bottom: 40px;
-`;
-
-const ProjectInfo = styled.div`
-  max-width: 60%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
-
-const ExternalLinkContainer = styled.div`
-  margin-left: auto;
-  flex-shrink: 0;
-`;
-
-const ContentSection = styled.div`
-  display: flex;
-  gap: 24px;
-  margin-bottom: 24px;
-`;
-
-const StyledPaper = styled.div`
-  flex: ${(props) => props.flex || 1};
-  background-color: #fff;
-  border-radius: 12px;
-  height: 30vh;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-`;
-
-const SectionHeader = styled.div`
-  padding: 16px;
-  padding-bottom: 0;
-  position: sticky;
-  top: 0;
-  background-color: #fff;
-  z-index: 1;
-`;
-
-const SectionContent = styled.div`
-  padding: 16px;
-  padding-top: 8px;
-  overflow-y: auto;
-  flex-grow: 1;
-`;

--- a/frontend/src/pages/Kanbanboard/index.jsx
+++ b/frontend/src/pages/Kanbanboard/index.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
 import Header from '../../components/features/Header';
-
-// eslint-disable-next-line import/extensions
-import SideMenu from '../../components/features/SideBar';
-
+import SideBar from '../../components/features/SideBar';
 import Kanban from '../../components/common/Kanban';
 
 const KanbanboardPage = () => (
@@ -16,26 +13,28 @@ const KanbanboardPage = () => (
     <Box
       sx={{
         position: 'fixed',
-        top: '76px',
+        top: '9vh',
         left: 0,
-        height: 'calc(100vh - 76px)',
+        height: 'calc(100vh - 9vh)',
+        width: '23vw',
         zIndex: 900,
       }}
     >
-      <SideMenu />
+      <SideBar />
     </Box>
 
     <Box
       component="main"
       sx={{
         position: 'fixed',
-        top: '76px',
-        left: '240px',
-        width: 'calc(100vw - 240px)',
-        height: 'calc(100vh - 76px)',
-        backgroundColor: '#f5f8ff',
+        top: '9vh',
+        left: '23vw',
+        width: 'calc(100vw - 23vw)',
+        height: 'calc(100vh - 9vh)',
+        backgroundColor: '#FAFAFA',
         padding: 4,
         overflowY: 'auto',
+        overflowX: 'auto',
         color: '#333',
       }}
     >
@@ -48,7 +47,7 @@ const KanbanboardPage = () => (
             variant="h4"
             sx={{
               fontWeight: 'bold',
-              fontSize: '4rem',
+              fontSize: '3.5rem',
               whiteSpace: 'nowrap',
               overflow: 'hidden',
               textOverflow: 'ellipsis',


### PR DESCRIPTION
## 📌 관련 이슈
#28 번다운 차트 페이지 구현

## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->
- 번다운 차트 페이지 레이아웃 구성
- 번다운 차트 컴포넌트 구현
- 대시보드 페이지 컴포넌트 디자인 수정
- 페이지 컴포넌트들 반응형 디자인으로 수정

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
<img width="1440" alt="스크린샷 2024-11-12 10 18 00" src="https://github.com/user-attachments/assets/554459eb-aa9a-4130-9bcb-f0dfb96ef159">
<img width="1437" alt="스크린샷 2024-11-12 10 20 05" src="https://github.com/user-attachments/assets/705eb8e9-0e59-4485-ac63-e0ead63880fd">
<img width="1440" alt="스크린샷 2024-11-12 10 18 41" src="https://github.com/user-attachments/assets/0ce28e26-ed8b-469a-9ac6-963d8c7496a0">
<img width="1438" alt="스크린샷 2024-11-12 10 19 19" src="https://github.com/user-attachments/assets/f3b3afef-dd6b-4075-bf46-de5bfc7a16aa">

