### PR TITLE
[Refactor]공통 사이드바 및 페이지 레이아웃 수정

### DIFF
--- a/frontend/src/components/common/BurndownChart/index.jsx
+++ b/frontend/src/components/common/BurndownChart/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Paper, Typography } from '@mui/material';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { LineChart } from '@mui/x-charts';
 import mockSprints from '../../../mocks/mockSprints';
 
@@ -30,7 +31,7 @@ const BurndownChart = () => {
           height: '100%',
           width: '100%',
           borderRadius: 3,
-          padding: 2,
+          padding: 0,
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'center',
@@ -38,16 +39,16 @@ const BurndownChart = () => {
         }}
         elevation={3}
       >
-        <Typography variant="h6" sx={{ fontSize: '35px' }}>
-            Burndown Chart
+        <Typography variant="h6" sx={{ fontSize: '35px', marginTop: '10px' }}>
+          Burndown Chart
         </Typography>
-        <Box 
-          sx={{ 
-            height: '90%', 
-            width: '90%', 
-            display: 'flex', 
-            justifyContent: 'center', 
-            alignItems: 'center' 
+        <Box
+          sx={{
+            height: '90%',
+            width: '90%',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
           }}
         >
           <LineChart

--- a/frontend/src/components/common/Member/index.jsx
+++ b/frontend/src/components/common/Member/index.jsx
@@ -58,18 +58,18 @@ Member.propTypes = {
 export default Member;
 
 const Container = styled.div`
-  padding: 20px;
+  padding: 0 2vw 2vh 2vw;
 `;
 
 const Header = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 15px;
+  margin-bottom: 1.5vh;
 `;
 
 const Title = styled.h3`
-  font-size: 20px;
+  font-size: 2vh;
   font-weight: bold;
   color: #333;
 `;
@@ -78,9 +78,9 @@ const InviteButton = styled.button`
   background-color: #ffd771;
   color: #fff;
   border: none;
-  border-radius: 5px;
-  padding: 5px 10px;
-  font-size: 14px;
+  border-radius: 0.5vw;
+  padding: 0.5vh 1vw;
+  font-size: 1.4vh;
   cursor: pointer;
 
   &:hover {
@@ -98,22 +98,22 @@ const MemberItem = styled.li`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 10px;
+  margin-bottom: 1vh;
 `;
 
 const MemberName = styled.span`
-  font-size: 16px;
+  font-size: 1.6vh;
   color: #333;
   display: flex;
   align-items: center;
   position: relative;
-  padding-left: 12px;
+  padding-left: 1.2vw;
 
   &::before {
     content: '';
     display: inline-block;
-    width: 6px;
-    height: 6px;
+    width: 0.6vw;
+    height: 0.6vw;
     background-color: #333;
     border-radius: 50%;
     position: absolute;
@@ -125,17 +125,17 @@ const MemberName = styled.span`
 
 const CrownIcon = styled.span`
   color: #ffd700;
-  margin-left: 5px;
-  font-size: 16px;
+  margin-left: 0.5vw;
+  font-size: 1.6vh;
 `;
 
 const KickButton = styled.button`
   background-color: #ffb3b3;
   color: white;
   border: none;
-  border-radius: 10px;
-  padding: 5px 10px;
-  font-size: 14px;
+  border-radius: 1vw;
+  padding: 0.5vh 1vw;
+  font-size: 1.4vh;
   cursor: pointer;
 
   &:hover {

--- a/frontend/src/components/common/NavigateMenu/index.jsx
+++ b/frontend/src/components/common/NavigateMenu/index.jsx
@@ -28,35 +28,35 @@ export default NavigateMenu;
 
 const Container = styled.div`
   width: 100%;
-  padding: 0 20px 20px 20px;
+  padding: 0 2vw;
 `;
 
 const Title = styled.h3`
   display: flex;
   align-items: center;
   align-self: flex-start;
-  font-size: 24px;
+  font-size: 2.4vh;
   font-weight: bold;
-  margin-bottom: 30px;
+  margin-bottom: 3vh;
   color: #151313;
 
   @media (max-width: 768px) {
-    font-size: 22px;
-    margin-bottom: 24px;
+    font-size: 2.2vh;
+    margin-bottom: 2.4vh;
   }
 
   @media (max-width: 480px) {
-    font-size: 20px;
-    margin-bottom: 20px;
+    font-size: 2vh;
+    margin-bottom: 2vh;
   }
 `;
 
 const MenuItem = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: 2vh;
   color: #666;
-  font-size: 18px;
+  font-size: 1.8vh;
   cursor: pointer;
   transition: color 0.3s;
 
@@ -65,29 +65,29 @@ const MenuItem = styled.div`
   }
 
   @media (max-width: 768px) {
-    font-size: 16px;
-    margin-bottom: 16px;
+    font-size: 1.6vh;
+    margin-bottom: 1.6vh;
   }
 
   @media (max-width: 480px) {
-    font-size: 14px;
-    margin-bottom: 12px;
+    font-size: 1.4vh;
+    margin-bottom: 1.2vh;
   }
 `;
 
 const Icon = styled.div`
-  font-size: 18px;
-  margin-right: 8px;
+  font-size: 1.8vh;
+  margin-right: 0.8vw;
 
   @media (max-width: 768px) {
-    font-size: 14px;
+    font-size: 1.4vh;
   }
 
   @media (max-width: 480px) {
-    font-size: 12px;
+    font-size: 1.2vh;
   }
 `;
 
 const MenuText = styled.span`
-  margin-left: 8px;
+  margin-left: 0.8vw;
 `;

--- a/frontend/src/components/common/NewProject/index.jsx
+++ b/frontend/src/components/common/NewProject/index.jsx
@@ -43,35 +43,35 @@ const Button = styled.button`
   background-color: #b0c9f8;
   color: #fff;
   border: none;
-  border-radius: 10px;
-  padding: 12px 20px;
-  font-size: 20px;
+  border-radius: 1vh;
+  padding: 1.2vh 2vw;
+  font-size: 2vh;
   font-family: 'PaperlogyBold';
   cursor: pointer;
   width: 23vw;
-  max-width: 300px;
-  min-width: 150px;
+  max-width: 30vw;
+  min-width: 15vw;
 
   @media (max-width: 768px) {
-    font-size: 13px;
-    padding: 10px 14px;
+    font-size: 1.3vh;
+    padding: 1vh 1.4vw;
   }
 
   @media (max-width: 480px) {
-    font-size: 12px;
-    padding: 8px 12px;
+    font-size: 1.2vh;
+    padding: 0.8vh 1.2vw;
   }
 `;
 
 const Icon = styled(FaFolderPlus)`
-  margin-right: 8px;
-  font-size: 20px;
+  margin-right: 0.8vw;
+  font-size: 2vh;
 
   @media (max-width: 768px) {
-    font-size: 13px;
+    font-size: 1.3vh;
   }
 
   @media (max-width: 480px) {
-    font-size: 12px;
+    font-size: 1.2vh;
   }
 `;

--- a/frontend/src/components/common/SelectProject/index.jsx
+++ b/frontend/src/components/common/SelectProject/index.jsx
@@ -41,17 +41,17 @@ export default SelectProject;
 const Container = styled.div`
   position: relative;
   width: 23vw;
-  max-width: 300px;
-  min-width: 150px;
-  padding: 10px;
-  border: 1px solid #e0e0e0;
-  border-radius: 5px;
+  max-width: 30vw;
+  min-width: 15vw;
+  padding: 1vh;
+  border: 0.1vw solid #e0e0e0;
+  border-radius: 0.5vw;
 `;
 
 const Selected = styled.div`
-  font-size: 20px;
+  font-size: 2vh;
   font-family: 'PaperlogyBold';
-  padding: 15px;
+  padding: 1.5vh;
   color: #7a7a7a;
   display: flex;
   justify-content: space-between;
@@ -59,13 +59,13 @@ const Selected = styled.div`
   cursor: pointer;
 
   @media (max-width: 768px) {
-    font-size: 14px;
-    padding: 12px;
+    font-size: 1.4vh;
+    padding: 1.2vh;
   }
 
   @media (max-width: 480px) {
-    font-size: 12px;
-    padding: 10px;
+    font-size: 1.2vh;
+    padding: 1vh;
   }
 `;
 
@@ -81,9 +81,9 @@ const Dropdown = styled.ul`
   left: 0;
   width: 100%;
   background-color: #ffffff;
-  border: 1px solid #e0e0e0;
-  border-radius: 5px;
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+  border: 0.1vw solid #e0e0e0;
+  border-radius: 0.5vw;
+  box-shadow: 0 0.4vh 0.8vh rgba(0, 0, 0, 0.1);
   z-index: 1;
   list-style-type: none;
   padding: 0;
@@ -91,23 +91,23 @@ const Dropdown = styled.ul`
 `;
 
 const Option = styled.li`
-  padding: 10px;
+  padding: 1vh;
   color: #666666;
   cursor: pointer;
   transition: background-color 0.2s;
-  font-size: 18px;
+  font-size: 1.8vh;
 
   &:hover {
     background-color: #f0f0f0;
   }
 
   @media (max-width: 768px) {
-    font-size: 16px;
-    padding: 8px;
+    font-size: 1.6vh;
+    padding: 0.8vh;
   }
 
   @media (max-width: 480px) {
-    font-size: 14px;
-    padding: 6px;
+    font-size: 1.4vh;
+    padding: 0.6vh;
   }
 `;

--- a/frontend/src/components/features/SideBar.jsx
+++ b/frontend/src/components/features/SideBar.jsx
@@ -8,8 +8,6 @@ import { IoHome } from 'react-icons/io5';
 // eslint-disable-next-line import/no-unresolved
 import NavigateMenu from '@components/common/NavigateMenu';
 // eslint-disable-next-line import/no-unresolved
-import { HEADER_HEIGHT } from '@components/features/Header';
-// eslint-disable-next-line import/no-unresolved
 import LogoutButton from '@components/common/LogoutButton';
 // eslint-disable-next-line import/no-unresolved
 import Member from '@components/common/Member';
@@ -55,17 +53,14 @@ export default SideBar;
 const SidebarContainer = styled.div`
   background-color: #fff;
   width: 23vw;
-  max-width: 400px;
-  min-width: 250px;
-  min-height: calc(100vh - ${HEADER_HEIGHT});
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 20px;
+  gap: 2vh;
 `;
 
 const CreateProjectButtonWrapper = styled.div`
-  margin-top: 20px;
+  margin-top: 2vh;
   width: 100%;
   display: flex;
   justify-content: center;
@@ -81,10 +76,10 @@ const DashboardLink = styled.a`
   display: flex;
   align-items: center;
   align-self: flex-start;
-  margin-top: 15px;
-  margin-left: 20px;
+  margin-top: 1.5vh;
+  margin-left: 2vw;
   color: #5f8f86;
-  font-size: 24px;
+  font-size: 2.4vh;
   text-decoration: none;
   cursor: pointer;
 
@@ -94,20 +89,19 @@ const DashboardLink = styled.a`
 `;
 
 const IoHomeIcon = styled(IoHome)`
-  margin-right: 8px;
-  font-size: 24px;
+  margin-right: 0.8vw;
+  font-size: 2.4vh;
   color: #5f8f86;
 `;
 
 const NavigateMenuWrapper = styled.div`
   width: 100%;
-  padding-left: 20px;
+  padding-left: 2vw;
 `;
 
 const MemberWrapper = styled.div`
   width: 100%;
-  padding-left: 20px;
-  margin-bottom: 25px;
+  padding-left: 2vw;
 `;
 
 const DividerWrapper = styled.div`
@@ -120,15 +114,13 @@ const DividerWrapper = styled.div`
 
 const Divider = styled.div`
   width: 100%;
-  height: 2px;
+  height: 0.2vh;
   background-color: #eaeaea;
-  margin-bottom: 25px;
 `;
 
 const LogoutButtonWrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: flex-start;
-  padding-left: 20px;
-  margin-top: auto;
+  padding-left: 2vw;
 `;

--- a/frontend/src/pages/Burndown/index.jsx
+++ b/frontend/src/pages/Burndown/index.jsx
@@ -1,44 +1,28 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
-import Header from '../../components/features/Header';
 import Sidebar from '../../components/features/SideBar';
 import BurndownChart from '../../components/common/BurndownChart';
 
 const BurndownPage = () => (
-  <Box sx={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
-    <Box sx={{ position: 'fixed', top: 0, width: '100%', zIndex: 1000 }}>
-      <Header />
-    </Box>
-
-    <Box
-      sx={{
-        position: 'fixed',
-        top: '9vh',
-        left: 0,
-        height: 'calc(100vh - 9vh)',
-        width: '23vw',
-        zIndex: 900,
-      }}
-    >
-      <Sidebar />
-    </Box>
+  <Box sx={{ display: 'flex', height: '100vh-9vh' }}>
+    <Sidebar />
 
     <Box
       component="main"
       sx={{
-        position: 'fixed',
-        top: '9vh',
         left: '23vw',
         width: 'calc(100vw - 23vw)',
         height: 'calc(100vh - 9vh)',
         backgroundColor: '#FAFAFA',
-        padding: 4,
+        padding: '0 20px',
         overflowY: 'auto',
         color: '#333',
       }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-        <Box sx={{ maxWidth: '60%', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        <Box
+          sx={{ maxWidth: '60%', overflow: 'hidden', textOverflow: 'ellipsis' }}
+        >
           <Typography variant="subtitle1">Project Name:</Typography>
           <Typography
             variant="h4"

--- a/frontend/src/pages/Dashboard/index.jsx
+++ b/frontend/src/pages/Dashboard/index.jsx
@@ -1,48 +1,47 @@
 import React from 'react';
 import { Box, Typography, Paper, Divider } from '@mui/material';
-import Header from '../../components/features/Header';
 import SideBar from '../../components/features/SideBar';
 import ExternalLinkButtons from '../../components/common/ExternalLinkButtons';
 import ProjectList from '../../components/common/ProjectList';
 import OngoingTasksList from '../../components/common/OngoingTasksList';
-import AgileNotesList from '../../components/common/AgileNotesList'
+import AgileNotesList from '../../components/common/AgileNotesList';
 
 const DashboardPage = () => (
-  <Box sx={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
-    <Box sx={{ position: 'fixed', top: 0, width: '100%', zIndex: 1000 }}>
-      <Header />
-    </Box>
-
-    <Box sx={{ position: 'fixed', top: '9vh', left: 0, height: 'calc(100vh - 9vh)', zIndex: 900 }}>
-      <SideBar />
-    </Box>
+  <Box sx={{ display: 'flex', height: '100vh-9vh' }}>
+    <SideBar />
 
     <Box
       component="main"
       sx={{
-        position: 'fixed',
-        top: '9vh',
         left: '23vw',
         width: 'calc(100vw - 23vw)',
         height: 'calc(100vh - 9vh)',
         backgroundColor: '#FAFAFA',
-        padding: 4,
         overflowY: 'auto',
         overflowX: 'auto',
       }}
     >
-      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', mb: 3 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-start',
+          mb: 3,
+          padding: '0 20px',
+        }}
+      >
         <Typography
           variant="h4"
           sx={{
             fontWeight: 'bold',
             color: '#333',
             fontSize: '4vh',
+            marginTop: '30px',
           }}
         >
           임지환님의 프로젝트
         </Typography>
-        
+
         <Box sx={{ mt: 2 }}>
           <ExternalLinkButtons />
         </Box>
@@ -60,7 +59,16 @@ const DashboardPage = () => (
             overflow: 'hidden',
           }}
         >
-          <Box sx={{ p: 2, pb: 0, position: 'sticky', top: 0, backgroundColor: '#fff', zIndex: 1 }}>
+          <Box
+            sx={{
+              p: 2,
+              pb: 0,
+              position: 'sticky',
+              top: 0,
+              backgroundColor: '#fff',
+              zIndex: 1,
+            }}
+          >
             <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1 }}>
               내 프로젝트
             </Typography>
@@ -82,7 +90,16 @@ const DashboardPage = () => (
             overflow: 'hidden',
           }}
         >
-          <Box sx={{ p: 2, pb: 0, position: 'sticky', top: 0, backgroundColor: '#fff', zIndex: 1 }}>
+          <Box
+            sx={{
+              p: 2,
+              pb: 0,
+              position: 'sticky',
+              top: 0,
+              backgroundColor: '#fff',
+              zIndex: 1,
+            }}
+          >
             <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1 }}>
               진행중인 작업
             </Typography>
@@ -104,7 +121,16 @@ const DashboardPage = () => (
           overflow: 'hidden',
         }}
       >
-        <Box sx={{ p: 2, pb: 0, position: 'sticky', top: 0, backgroundColor: '#fff', zIndex: 1 }}>
+        <Box
+          sx={{
+            p: 2,
+            pb: 0,
+            position: 'sticky',
+            top: 0,
+            backgroundColor: '#fff',
+            zIndex: 1,
+          }}
+        >
           <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1 }}>
             애자일 학습하기
           </Typography>

--- a/frontend/src/pages/Kanbanboard/index.jsx
+++ b/frontend/src/pages/Kanbanboard/index.jsx
@@ -1,38 +1,20 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
-import Header from '../../components/features/Header';
 import SideBar from '../../components/features/SideBar';
 import Kanban from '../../components/common/Kanban';
 
 const KanbanboardPage = () => (
-  <Box sx={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
-    <Box sx={{ position: 'fixed', top: 0, width: '100%', zIndex: 1000 }}>
-      <Header />
-    </Box>
-
-    <Box
-      sx={{
-        position: 'fixed',
-        top: '9vh',
-        left: 0,
-        height: 'calc(100vh - 9vh)',
-        width: '23vw',
-        zIndex: 900,
-      }}
-    >
-      <SideBar />
-    </Box>
+  <Box sx={{ display: 'flex', height: '100vh-9vh' }}>
+    <SideBar />
 
     <Box
       component="main"
       sx={{
-        position: 'fixed',
-        top: '9vh',
         left: '23vw',
         width: 'calc(100vw - 23vw)',
         height: 'calc(100vh - 9vh)',
         backgroundColor: '#FAFAFA',
-        padding: 4,
+        padding: '0 20px',
         overflowY: 'auto',
         overflowX: 'auto',
         color: '#333',


### PR DESCRIPTION
## 📌 관련 이슈
#36 공통 사이드바 및 페이지 레이아웃 수정

## ✨ PR 내용
- KanbanboardPage 컴포넌트의 레이아웃 수정
  - 헤더와 사이드바 위치 조정
  - Kanban 보드의 메인 영역 스타일을 개선하여 padding 및 overflow 속성 수정
  - 화면 크기에 따라 반응형으로 height와 width 속성을 설정하여 레이아웃 일관성 유지
- 스타일 및 UI 개선
  - KanbanboardPage의 padding, margin, background-color 등 UI 요소의 스타일 조정
  - 색상 및 간격 조정으로 사용자 경험 향상

## 📸 스크린샷(선택)
### 칸반보드 페이지
![image](https://github.com/user-attachments/assets/8e4cd5ab-dd74-4185-bdbf-cf59cf5889f7)
### 대시보드 페이지
![image](https://github.com/user-attachments/assets/67f5160a-0c39-48ed-b51d-2cea6deb32b0)
### 번다운 차트 페이지
![image](https://github.com/user-attachments/assets/623dc2dd-cf05-41d7-b5c4-b0a69225d0b4)
