### PR TITLE
[FEAT] 프로젝트 회원 관리 기능 및 초대 관련 구현

### DIFF
--- a/backend/src/main/java/agilementor/common/exception/AlreadyJoinedMemberException.java
+++ b/backend/src/main/java/agilementor/common/exception/AlreadyJoinedMemberException.java
@@ -1,0 +1,10 @@
+package agilementor.common.exception;
+
+public class AlreadyJoinedMemberException extends RuntimeException {
+
+  private static final String MESSAGE = "이미 프로젝트에 참가한 회원입니다.";
+
+    public AlreadyJoinedMemberException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/java/agilementor/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/agilementor/common/exception/GlobalExceptionHandler.java
@@ -57,8 +57,16 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
-    public ResponseEntity<ExceptionResponse> handleAlreadyJoinedMemberExceptionException(
+    public ResponseEntity<ExceptionResponse> handleAlreadyJoinedMemberException(
         AlreadyJoinedMemberException exception) {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(new ExceptionResponse(exception.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ExceptionResponse> handleInvitationNotFoundException(
+        InvalidInvitationException exception) {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(new ExceptionResponse(exception.getMessage()));

--- a/backend/src/main/java/agilementor/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/agilementor/common/exception/GlobalExceptionHandler.java
@@ -48,4 +48,12 @@ public class GlobalExceptionHandler {
             .body(new ExceptionResponse(exception.getMessage()));
     }
 
+    @ExceptionHandler
+    public ResponseEntity<ExceptionResponse> handleKickOneselfException(
+        KickOneselfException exception) {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(new ExceptionResponse(exception.getMessage()));
+    }
+
 }

--- a/backend/src/main/java/agilementor/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/agilementor/common/exception/GlobalExceptionHandler.java
@@ -56,4 +56,11 @@ public class GlobalExceptionHandler {
             .body(new ExceptionResponse(exception.getMessage()));
     }
 
+    @ExceptionHandler
+    public ResponseEntity<ExceptionResponse> handleAlreadyJoinedMemberExceptionException(
+        AlreadyJoinedMemberException exception) {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(new ExceptionResponse(exception.getMessage()));
+    }
 }

--- a/backend/src/main/java/agilementor/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/agilementor/common/exception/GlobalExceptionHandler.java
@@ -40,4 +40,12 @@ public class GlobalExceptionHandler {
             .body(new ExceptionResponse(exception.getMessage()));
     }
 
+    @ExceptionHandler
+    public ResponseEntity<ExceptionResponse> handleNotProjectAdminException(
+        NotProjectAdminException exception) {
+        return ResponseEntity
+            .status(HttpStatus.FORBIDDEN)
+            .body(new ExceptionResponse(exception.getMessage()));
+    }
+
 }

--- a/backend/src/main/java/agilementor/common/exception/InvalidInvitationException.java
+++ b/backend/src/main/java/agilementor/common/exception/InvalidInvitationException.java
@@ -1,0 +1,10 @@
+package agilementor.common.exception;
+
+public class InvalidInvitationException extends RuntimeException {
+
+    private static final String MESSAGE = "유효하지 않은 초대입니다.";
+
+    public InvalidInvitationException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/java/agilementor/common/exception/KickOneselfException.java
+++ b/backend/src/main/java/agilementor/common/exception/KickOneselfException.java
@@ -1,0 +1,10 @@
+package agilementor.common.exception;
+
+public class KickOneselfException extends RuntimeException {
+
+    private static final String MESSAGE = "자기 자신을 프로젝트에서 추방할 수 없습니다.";
+
+    public KickOneselfException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/java/agilementor/common/exception/MemberNotFoundException.java
+++ b/backend/src/main/java/agilementor/common/exception/MemberNotFoundException.java
@@ -2,7 +2,7 @@ package agilementor.common.exception;
 
 public class MemberNotFoundException extends RuntimeException {
 
-    private static final String MESSAGE = "해당 회원이 존재하지 않습니다.";
+    private static final String MESSAGE = "해당 회원을 찾을 수 없습니다.";
 
     public MemberNotFoundException() {
         super(MESSAGE);

--- a/backend/src/main/java/agilementor/common/exception/NotProjectAdminException.java
+++ b/backend/src/main/java/agilementor/common/exception/NotProjectAdminException.java
@@ -2,7 +2,7 @@ package agilementor.common.exception;
 
 public class NotProjectAdminException extends RuntimeException {
 
-    private static final String MESSAGE = "해당 회원이 존재하지 않습니다.";
+    private static final String MESSAGE = "프로젝트 관리자가 아닙니다.";
 
     public NotProjectAdminException() {
         super(MESSAGE);

--- a/backend/src/main/java/agilementor/common/exception/NotProjectAdminException.java
+++ b/backend/src/main/java/agilementor/common/exception/NotProjectAdminException.java
@@ -1,0 +1,10 @@
+package agilementor.common.exception;
+
+public class NotProjectAdminException extends RuntimeException {
+
+    private static final String MESSAGE = "해당 회원이 존재하지 않습니다.";
+
+    public NotProjectAdminException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/java/agilementor/project/controller/InvitationController.java
+++ b/backend/src/main/java/agilementor/project/controller/InvitationController.java
@@ -3,8 +3,12 @@ package agilementor.project.controller;
 import agilementor.project.dto.response.InvitationGetResponse;
 import agilementor.project.service.InvitationService;
 import java.util.List;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.SessionAttribute;
 
@@ -25,4 +29,11 @@ public class InvitationController {
         return invitationService.getInvitationList(memberId);
     }
 
+    @PostMapping("/{invitationId}/accept")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void acceptInvitation(@PathVariable Long invitationId,
+        @SessionAttribute("memberId") Long memberId) {
+
+        invitationService.acceptInvitation(memberId, invitationId);
+    }
 }

--- a/backend/src/main/java/agilementor/project/controller/InvitationController.java
+++ b/backend/src/main/java/agilementor/project/controller/InvitationController.java
@@ -36,4 +36,12 @@ public class InvitationController {
 
         invitationService.acceptInvitation(memberId, invitationId);
     }
+
+    @PostMapping("/{invitationId}/decline")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void declineInvitation(@PathVariable Long invitationId,
+        @SessionAttribute("memberId") Long memberId) {
+
+        invitationService.declineInvitation(memberId, invitationId);
+    }
 }

--- a/backend/src/main/java/agilementor/project/controller/InvitationController.java
+++ b/backend/src/main/java/agilementor/project/controller/InvitationController.java
@@ -1,0 +1,28 @@
+package agilementor.project.controller;
+
+import agilementor.project.dto.response.InvitationGetResponse;
+import agilementor.project.service.InvitationService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+@RestController
+@RequestMapping("/api/invitations")
+public class InvitationController {
+
+    private final InvitationService invitationService;
+
+    public InvitationController(InvitationService invitationService) {
+        this.invitationService = invitationService;
+    }
+
+    @GetMapping
+    public List<InvitationGetResponse> getInvitationList(
+        @SessionAttribute("memberId") Long memberId) {
+
+        return invitationService.getInvitationList(memberId);
+    }
+
+}

--- a/backend/src/main/java/agilementor/project/controller/ProjectController.java
+++ b/backend/src/main/java/agilementor/project/controller/ProjectController.java
@@ -1,6 +1,5 @@
 package agilementor.project.controller;
 
-import agilementor.member.dto.response.MemberGetResponse;
 import agilementor.project.dto.request.ProjectCreateRequest;
 import agilementor.project.dto.request.ProjectUpdateRequest;
 import agilementor.project.dto.response.ProjectResponse;
@@ -47,13 +46,6 @@ public class ProjectController {
         @PathVariable Long projectId) {
 
         return projectService.getProject(memberId, projectId);
-    }
-
-    @GetMapping("/{projectId}/members")
-    public List<MemberGetResponse> getProjectMemberList(@SessionAttribute("memberId") Long memberId,
-        @PathVariable Long projectId) {
-
-        return projectService.getProjectMemberList(memberId, projectId);
     }
 
     @PutMapping("/{projectId}")

--- a/backend/src/main/java/agilementor/project/controller/ProjectController.java
+++ b/backend/src/main/java/agilementor/project/controller/ProjectController.java
@@ -70,4 +70,12 @@ public class ProjectController {
 
         projectService.deleteProject(memberId, projectId);
     }
+
+    @PostMapping("/{projectId}/leave")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void leaveProject(@SessionAttribute("memberId") Long memberId,
+        @PathVariable Long projectId) {
+
+        projectService.leaveProject(memberId, projectId);
+    }
 }

--- a/backend/src/main/java/agilementor/project/controller/ProjectMemberController.java
+++ b/backend/src/main/java/agilementor/project/controller/ProjectMemberController.java
@@ -1,0 +1,28 @@
+package agilementor.project.controller;
+
+import agilementor.member.dto.response.MemberGetResponse;
+import agilementor.project.service.ProjectMemberService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+@RestController
+@RequestMapping("/api/projects/{projectId}")
+public class ProjectMemberController {
+
+    private final ProjectMemberService projectMemberService;
+
+    public ProjectMemberController(ProjectMemberService projectMemberService) {
+        this.projectMemberService = projectMemberService;
+    }
+
+    @GetMapping("/members")
+    public List<MemberGetResponse> getProjectMemberList(@SessionAttribute("memberId") Long memberId,
+        @PathVariable Long projectId) {
+
+        return projectMemberService.getProjectMemberList(memberId, projectId);
+    }
+}

--- a/backend/src/main/java/agilementor/project/controller/ProjectMemberController.java
+++ b/backend/src/main/java/agilementor/project/controller/ProjectMemberController.java
@@ -1,12 +1,15 @@
 package agilementor.project.controller;
 
 import agilementor.member.dto.response.MemberGetResponse;
+import agilementor.project.dto.request.ProjectInviteRequest;
 import agilementor.project.service.ProjectMemberService;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,5 +38,13 @@ public class ProjectMemberController {
         @PathVariable Long projectId, @PathVariable Long memberId) {
 
         projectMemberService.kickMember(loginMemberId, projectId, memberId);
+    }
+
+    @PostMapping("/invitaions")
+    @ResponseStatus(HttpStatus.OK)
+    public void inviteMember(@SessionAttribute("memberId") Long loginMemberId,
+        @PathVariable Long projectId, @RequestBody ProjectInviteRequest projectInviteRequest) {
+
+        projectMemberService.inviteMember(loginMemberId, projectId, projectInviteRequest);
     }
 }

--- a/backend/src/main/java/agilementor/project/controller/ProjectMemberController.java
+++ b/backend/src/main/java/agilementor/project/controller/ProjectMemberController.java
@@ -3,9 +3,12 @@ package agilementor.project.controller;
 import agilementor.member.dto.response.MemberGetResponse;
 import agilementor.project.service.ProjectMemberService;
 import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.SessionAttribute;
 
@@ -24,5 +27,13 @@ public class ProjectMemberController {
         @PathVariable Long projectId) {
 
         return projectMemberService.getProjectMemberList(memberId, projectId);
+    }
+
+    @DeleteMapping("/members/{memberId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void kickMember(@SessionAttribute("memberId") Long loginMemberId,
+        @PathVariable Long projectId, @PathVariable Long memberId) {
+
+        projectMemberService.kickMember(loginMemberId, projectId, memberId);
     }
 }

--- a/backend/src/main/java/agilementor/project/controller/ProjectMemberController.java
+++ b/backend/src/main/java/agilementor/project/controller/ProjectMemberController.java
@@ -2,6 +2,7 @@ package agilementor.project.controller;
 
 import agilementor.member.dto.response.MemberGetResponse;
 import agilementor.project.dto.request.ProjectInviteRequest;
+import agilementor.project.dto.response.ProejctMemberResponse;
 import agilementor.project.service.ProjectMemberService;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -26,7 +27,7 @@ public class ProjectMemberController {
     }
 
     @GetMapping("/members")
-    public List<MemberGetResponse> getProjectMemberList(@SessionAttribute("memberId") Long memberId,
+    public List<ProejctMemberResponse> getProjectMemberList(@SessionAttribute("memberId") Long memberId,
         @PathVariable Long projectId) {
 
         return projectMemberService.getProjectMemberList(memberId, projectId);

--- a/backend/src/main/java/agilementor/project/dto/request/ProjectInviteRequest.java
+++ b/backend/src/main/java/agilementor/project/dto/request/ProjectInviteRequest.java
@@ -1,0 +1,7 @@
+package agilementor.project.dto.request;
+
+public record ProjectInviteRequest(
+    String email
+) {
+
+}

--- a/backend/src/main/java/agilementor/project/dto/response/InvitationGetResponse.java
+++ b/backend/src/main/java/agilementor/project/dto/response/InvitationGetResponse.java
@@ -1,0 +1,18 @@
+package agilementor.project.dto.response;
+
+import agilementor.project.entity.Invitation;
+
+public record InvitationGetResponse(
+    Long invitationId,
+    String projectTitle,
+    String invitorName
+) {
+
+    public static InvitationGetResponse from(Invitation invitation) {
+        Long invitationId = invitation.getInvitationId();
+        String projectTitle = invitation.getProject().getTitle();
+        String invitorName = invitation.getInvitor().getName();
+
+        return new InvitationGetResponse(invitationId, projectTitle, invitorName);
+    }
+}

--- a/backend/src/main/java/agilementor/project/dto/response/ProejctMemberResponse.java
+++ b/backend/src/main/java/agilementor/project/dto/response/ProejctMemberResponse.java
@@ -1,0 +1,18 @@
+package agilementor.project.dto.response;
+
+import agilementor.member.entity.Member;
+import agilementor.project.entity.ProjectMember;
+
+public record ProejctMemberResponse(
+    Long memberId,
+    String name,
+    String profileImageUrl,
+    boolean isAdmin
+) {
+
+    public static ProejctMemberResponse from(ProjectMember projectMember) {
+        Member member = projectMember.getMember();
+        return new ProejctMemberResponse(member.getMemberId(), member.getName(),
+            member.getPicture(), projectMember.isAdmin());
+    }
+}

--- a/backend/src/main/java/agilementor/project/entity/Invitation.java
+++ b/backend/src/main/java/agilementor/project/entity/Invitation.java
@@ -16,15 +16,15 @@ public class Invitation {
     private Long invitationId;
 
     @ManyToOne
-    @JoinColumn(name = "project_id")
+    @JoinColumn(name = "project_id", nullable = false)
     private Project project;
 
     @ManyToOne
-    @JoinColumn(name = "invitee_id")
+    @JoinColumn(name = "invitee_id", nullable = false)
     private Member invitee;
 
     @ManyToOne
-    @JoinColumn(name = "invitor_id")
+    @JoinColumn(name = "invitor_id", nullable = false)
     private Member invitor;
 
     protected Invitation() {

--- a/backend/src/main/java/agilementor/project/entity/Invitation.java
+++ b/backend/src/main/java/agilementor/project/entity/Invitation.java
@@ -20,15 +20,20 @@ public class Invitation {
     private Project project;
 
     @ManyToOne
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @JoinColumn(name = "invitee_id")
+    private Member invitee;
+
+    @ManyToOne
+    @JoinColumn(name = "invitor_id")
+    private Member invitor;
 
     protected Invitation() {
     }
 
-    public Invitation(Project project, Member member) {
+    public Invitation(Project project, Member invitee, Member invitor) {
         this.project = project;
-        this.member = member;
+        this.invitee = invitee;
+        this.invitor = invitor;
     }
 
     public Long getInvitationId() {
@@ -39,7 +44,7 @@ public class Invitation {
         return project;
     }
 
-    public Member getMember() {
-        return member;
+    public Member getInvitee() {
+        return invitee;
     }
 }

--- a/backend/src/main/java/agilementor/project/entity/Invitation.java
+++ b/backend/src/main/java/agilementor/project/entity/Invitation.java
@@ -47,4 +47,8 @@ public class Invitation {
     public Member getInvitee() {
         return invitee;
     }
+
+    public Member getInvitor() {
+        return invitor;
+    }
 }

--- a/backend/src/main/java/agilementor/project/entity/Invitation.java
+++ b/backend/src/main/java/agilementor/project/entity/Invitation.java
@@ -1,0 +1,45 @@
+package agilementor.project.entity;
+
+import agilementor.member.entity.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Invitation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long invitationId;
+
+    @ManyToOne
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    protected Invitation() {
+    }
+
+    public Invitation(Project project, Member member) {
+        this.project = project;
+        this.member = member;
+    }
+
+    public Long getInvitationId() {
+        return invitationId;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+}

--- a/backend/src/main/java/agilementor/project/entity/ProjectMember.java
+++ b/backend/src/main/java/agilementor/project/entity/ProjectMember.java
@@ -42,6 +42,10 @@ public class ProjectMember {
         return member;
     }
 
+    public boolean isAdmin() {
+        return is_admin;
+    }
+
     public boolean isNotAdmin() {
         return !is_admin;
     }

--- a/backend/src/main/java/agilementor/project/entity/ProjectMember.java
+++ b/backend/src/main/java/agilementor/project/entity/ProjectMember.java
@@ -41,6 +41,10 @@ public class ProjectMember {
     public Member getMember() {
         return member;
     }
+
+    public boolean isNotAdmin() {
+        return !is_admin;
+    }
 }
 
 

--- a/backend/src/main/java/agilementor/project/entity/ProjectMember.java
+++ b/backend/src/main/java/agilementor/project/entity/ProjectMember.java
@@ -23,12 +23,15 @@ public class ProjectMember {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    private boolean is_admin;
+
     protected ProjectMember() {
     }
 
-    public ProjectMember(Project project, Member member) {
+    public ProjectMember(Project project, Member member, boolean is_admin) {
         this.project = project;
         this.member = member;
+        this.is_admin = is_admin;
     }
 
     public Project getProject() {

--- a/backend/src/main/java/agilementor/project/repository/InvitationRepository.java
+++ b/backend/src/main/java/agilementor/project/repository/InvitationRepository.java
@@ -3,9 +3,15 @@ package agilementor.project.repository;
 import agilementor.member.entity.Member;
 import agilementor.project.entity.Invitation;
 import agilementor.project.entity.Project;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface InvitationRepository extends JpaRepository<Invitation, Long> {
 
     boolean existsByProjectAndInvitee(Project project, Member invitee);
+
+    @Query("SELECT DISTINCT i FROM Invitation i JOIN FETCH i.project, i.invitor WHERE i.invitee.memberId = :memberId")
+    List<Invitation> findByInviteeId(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/agilementor/project/repository/InvitationRepository.java
+++ b/backend/src/main/java/agilementor/project/repository/InvitationRepository.java
@@ -1,0 +1,11 @@
+package agilementor.project.repository;
+
+import agilementor.member.entity.Member;
+import agilementor.project.entity.Invitation;
+import agilementor.project.entity.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InvitationRepository extends JpaRepository<Invitation, Long> {
+
+    boolean existsByMemberAndProject(Member member, Project project);
+}

--- a/backend/src/main/java/agilementor/project/repository/InvitationRepository.java
+++ b/backend/src/main/java/agilementor/project/repository/InvitationRepository.java
@@ -12,6 +12,6 @@ public interface InvitationRepository extends JpaRepository<Invitation, Long> {
 
     boolean existsByProjectAndInvitee(Project project, Member invitee);
 
-    @Query("SELECT DISTINCT i FROM Invitation i JOIN FETCH i.project, i.invitor WHERE i.invitee.memberId = :memberId")
+    @Query("SELECT DISTINCT i FROM Invitation i JOIN FETCH i.project JOIN FETCH i.invitor WHERE i.invitee.memberId = :memberId")
     List<Invitation> findByInviteeId(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/agilementor/project/repository/InvitationRepository.java
+++ b/backend/src/main/java/agilementor/project/repository/InvitationRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InvitationRepository extends JpaRepository<Invitation, Long> {
 
-    boolean existsByMemberAndProject(Member member, Project project);
+    boolean existsByProjectAndInvitee(Project project, Member invitee);
 }

--- a/backend/src/main/java/agilementor/project/service/InvitationService.java
+++ b/backend/src/main/java/agilementor/project/service/InvitationService.java
@@ -44,4 +44,15 @@ public class InvitationService {
 
         invitationRepository.delete(invitation);
     }
+
+    public void declineInvitation(Long memberId, Long invitationId) {
+        Invitation invitation = invitationRepository.findById(invitationId)
+            .orElseThrow(InvalidInvitationException::new);
+
+        if (!invitation.getInvitee().getMemberId().equals(memberId)) {
+            throw new InvalidInvitationException();
+        }
+
+        invitationRepository.delete(invitation);
+    }
 }

--- a/backend/src/main/java/agilementor/project/service/InvitationService.java
+++ b/backend/src/main/java/agilementor/project/service/InvitationService.java
@@ -1,18 +1,26 @@
 package agilementor.project.service;
 
+import agilementor.common.exception.InvalidInvitationException;
 import agilementor.project.dto.response.InvitationGetResponse;
 import agilementor.project.entity.Invitation;
+import agilementor.project.entity.ProjectMember;
 import agilementor.project.repository.InvitationRepository;
+import agilementor.project.repository.ProjectMemberRepository;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
 @Service
+@Transactional
 public class InvitationService {
 
     private final InvitationRepository invitationRepository;
+    private final ProjectMemberRepository projectMemberRepository;
 
-    public InvitationService(InvitationRepository invitationRepository) {
+    public InvitationService(InvitationRepository invitationRepository,
+        ProjectMemberRepository projectMemberRepository) {
         this.invitationRepository = invitationRepository;
+        this.projectMemberRepository = projectMemberRepository;
     }
 
     public List<InvitationGetResponse> getInvitationList(Long memberId) {
@@ -21,5 +29,19 @@ public class InvitationService {
         return invitationList.stream()
             .map(InvitationGetResponse::from)
             .toList();
+    }
+
+    public void acceptInvitation(Long memberId, Long invitationId) {
+        Invitation invitation = invitationRepository.findById(invitationId)
+            .orElseThrow(InvalidInvitationException::new);
+
+        if (!invitation.getInvitee().getMemberId().equals(memberId)) {
+            throw new InvalidInvitationException();
+        }
+
+        projectMemberRepository.save(
+            new ProjectMember(invitation.getProject(), invitation.getInvitee(), false));
+
+        invitationRepository.delete(invitation);
     }
 }

--- a/backend/src/main/java/agilementor/project/service/InvitationService.java
+++ b/backend/src/main/java/agilementor/project/service/InvitationService.java
@@ -1,0 +1,25 @@
+package agilementor.project.service;
+
+import agilementor.project.dto.response.InvitationGetResponse;
+import agilementor.project.entity.Invitation;
+import agilementor.project.repository.InvitationRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InvitationService {
+
+    private final InvitationRepository invitationRepository;
+
+    public InvitationService(InvitationRepository invitationRepository) {
+        this.invitationRepository = invitationRepository;
+    }
+
+    public List<InvitationGetResponse> getInvitationList(Long memberId) {
+        List<Invitation> invitationList = invitationRepository.findByInviteeId(memberId);
+
+        return invitationList.stream()
+            .map(InvitationGetResponse::from)
+            .toList();
+    }
+}

--- a/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
+++ b/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
@@ -1,0 +1,37 @@
+package agilementor.project.service;
+
+import agilementor.common.exception.ProjectNotFoundException;
+import agilementor.member.dto.response.MemberGetResponse;
+import agilementor.project.entity.ProjectMember;
+import agilementor.project.repository.ProjectMemberRepository;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+public class ProjectMemberService {
+
+    private final ProjectMemberRepository projectMemberRepository;
+
+    public ProjectMemberService(ProjectMemberRepository projectMemberRepository) {
+        this.projectMemberRepository = projectMemberRepository;
+    }
+
+    public List<MemberGetResponse> getProjectMemberList(Long memberId, Long projectId) {
+
+        List<ProjectMember> projectMemberList = projectMemberRepository.findByProjectId(projectId);
+
+        boolean isNotMemberOfProject = projectMemberList.stream()
+            .noneMatch(projectMember -> projectMember.getMember().getMemberId().equals(memberId));
+
+        if (isNotMemberOfProject) {
+            throw new ProjectNotFoundException();
+        }
+
+        return projectMemberList.stream()
+            .map(projectMember -> MemberGetResponse.from(projectMember.getMember()))
+            .toList();
+    }
+
+}

--- a/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
+++ b/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
@@ -1,24 +1,41 @@
 package agilementor.project.service;
 
+import agilementor.common.exception.AlreadyJoinedMemberException;
 import agilementor.common.exception.KickOneselfException;
 import agilementor.common.exception.MemberNotFoundException;
 import agilementor.common.exception.NotProjectAdminException;
 import agilementor.common.exception.ProjectNotFoundException;
 import agilementor.member.dto.response.MemberGetResponse;
+import agilementor.member.entity.Member;
+import agilementor.member.repository.MemberRepository;
+import agilementor.project.dto.request.ProjectInviteRequest;
+import agilementor.project.entity.Invitation;
+import agilementor.project.entity.Project;
 import agilementor.project.entity.ProjectMember;
+import agilementor.project.repository.InvitationRepository;
 import agilementor.project.repository.ProjectMemberRepository;
+import agilementor.project.repository.ProjectRespository;
 import jakarta.transaction.Transactional;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 
 @Service
 @Transactional
 public class ProjectMemberService {
 
+    private final MemberRepository memberRepository;
+    private final ProjectRespository projectRespository;
     private final ProjectMemberRepository projectMemberRepository;
+    private final InvitationRepository invitationRepository;
 
-    public ProjectMemberService(ProjectMemberRepository projectMemberRepository) {
+    public ProjectMemberService(MemberRepository memberRepository,
+        ProjectRespository projectRespository, ProjectMemberRepository projectMemberRepository,
+        InvitationRepository invitationRepository) {
+        this.memberRepository = memberRepository;
+        this.projectRespository = projectRespository;
         this.projectMemberRepository = projectMemberRepository;
+        this.invitationRepository = invitationRepository;
     }
 
     public List<MemberGetResponse> getProjectMemberList(Long memberId, Long projectId) {
@@ -45,14 +62,7 @@ public class ProjectMemberService {
             throw new ProjectNotFoundException();
         }
 
-        ProjectMember loginProjectMember = projectMemberList.stream()
-            .filter(projectMember -> projectMember.getMember().getMemberId().equals(loginMemberId))
-            .findFirst()
-            .orElseThrow(MemberNotFoundException::new);
-
-        if (loginProjectMember.isNotAdmin()) {
-            throw new NotProjectAdminException();
-        }
+        checkAdmin(loginMemberId, projectMemberList);
 
         if (loginMemberId.equals(targetMemberId)) {
             throw new KickOneselfException();
@@ -64,5 +74,60 @@ public class ProjectMemberService {
             .orElseThrow(MemberNotFoundException::new);
 
         projectMemberRepository.delete(targetProjectMember);
+    }
+
+    public void inviteMember(Long loginMemberId, Long projectId,
+        ProjectInviteRequest projectInviteRequest) {
+        String targetEmail = projectInviteRequest.email();
+
+        List<ProjectMember> projectMemberList = projectMemberRepository.findByProjectId(projectId);
+
+        if (projectMemberList.isEmpty()) {
+            throw new ProjectNotFoundException();
+        }
+
+        checkAdmin(loginMemberId, projectMemberList);
+
+        boolean isAlreadyMember = projectMemberList.stream()
+            .anyMatch(projectMember -> projectMember.getMember().getEmail().equals(targetEmail));
+
+        if (isAlreadyMember) {
+            throw new AlreadyJoinedMemberException();
+        }
+
+        Optional<Member> target = memberRepository.findByEmail(targetEmail);
+        if (target.isEmpty()) {
+            // 해당 이메일을 가진 회원이 없다면 실제 초대 작업 안 함
+            // 가입한 회원인지 알 수 없도록 성공 응답 함
+            // 추후 초대 메일을 보내거나 가입한 회원이 아니라고 응답하는식으로 수정 가능
+            // 초대 메일을 보낸다면 비회원 초대 내역도 저장하도록 수정 필요
+            return;
+        }
+
+        Project project = projectRespository.findById(projectId)
+            .orElseThrow(ProjectNotFoundException::new);
+
+        boolean isAlreadyInvited = invitationRepository
+            .existsByMemberAndProject(target.get(), project);
+
+        if (isAlreadyInvited) {
+            // 이미 초대된 회원일 경우에도 아무 작업 안 하고 성공 응답.
+            return;
+        }
+
+
+        Invitation invitation = new Invitation(project, target.get());
+        invitationRepository.save(invitation);
+    }
+
+    private static void checkAdmin(Long loginMemberId, List<ProjectMember> projectMemberList) {
+        ProjectMember loginProjectMember = projectMemberList.stream()
+            .filter(projectMember -> projectMember.getMember().getMemberId().equals(loginMemberId))
+            .findFirst()
+            .orElseThrow(MemberNotFoundException::new);
+
+        if (loginProjectMember.isNotAdmin()) {
+            throw new NotProjectAdminException();
+        }
     }
 }

--- a/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
+++ b/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
@@ -1,5 +1,8 @@
 package agilementor.project.service;
 
+import agilementor.common.exception.KickOneselfException;
+import agilementor.common.exception.MemberNotFoundException;
+import agilementor.common.exception.NotProjectAdminException;
 import agilementor.common.exception.ProjectNotFoundException;
 import agilementor.member.dto.response.MemberGetResponse;
 import agilementor.project.entity.ProjectMember;
@@ -34,4 +37,32 @@ public class ProjectMemberService {
             .toList();
     }
 
+    public void kickMember(Long loginMemberId, Long projectId, Long targetMemberId) {
+
+        List<ProjectMember> projectMemberList = projectMemberRepository.findByProjectId(projectId);
+
+        if (projectMemberList.isEmpty()) {
+            throw new ProjectNotFoundException();
+        }
+
+        ProjectMember loginProjectMember = projectMemberList.stream()
+            .filter(projectMember -> projectMember.getMember().getMemberId().equals(loginMemberId))
+            .findFirst()
+            .orElseThrow(MemberNotFoundException::new);
+
+        if (loginProjectMember.isNotAdmin()) {
+            throw new NotProjectAdminException();
+        }
+
+        if (loginMemberId.equals(targetMemberId)) {
+            throw new KickOneselfException();
+        }
+
+        ProjectMember targetProjectMember = projectMemberList.stream()
+            .filter(projectMember -> projectMember.getMember().getMemberId().equals(loginMemberId))
+            .findFirst()
+            .orElseThrow(MemberNotFoundException::new);
+
+        projectMemberRepository.delete(targetProjectMember);
+    }
 }

--- a/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
+++ b/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
@@ -108,15 +108,17 @@ public class ProjectMemberService {
             .orElseThrow(ProjectNotFoundException::new);
 
         boolean isAlreadyInvited = invitationRepository
-            .existsByMemberAndProject(target.get(), project);
+            .existsByProjectAndInvitee(project, target.get());
 
         if (isAlreadyInvited) {
             // 이미 초대된 회원일 경우에도 아무 작업 안 하고 성공 응답.
             return;
         }
 
+        Member invitor = memberRepository.findById(loginMemberId)
+            .orElseThrow(MemberNotFoundException::new);
 
-        Invitation invitation = new Invitation(project, target.get());
+        Invitation invitation = new Invitation(project, target.get(), invitor);
         invitationRepository.save(invitation);
     }
 

--- a/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
+++ b/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
@@ -59,7 +59,7 @@ public class ProjectMemberService {
         }
 
         ProjectMember targetProjectMember = projectMemberList.stream()
-            .filter(projectMember -> projectMember.getMember().getMemberId().equals(loginMemberId))
+            .filter(projectMember -> projectMember.getMember().getMemberId().equals(targetMemberId))
             .findFirst()
             .orElseThrow(MemberNotFoundException::new);
 

--- a/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
+++ b/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
@@ -5,10 +5,10 @@ import agilementor.common.exception.KickOneselfException;
 import agilementor.common.exception.MemberNotFoundException;
 import agilementor.common.exception.NotProjectAdminException;
 import agilementor.common.exception.ProjectNotFoundException;
-import agilementor.member.dto.response.MemberGetResponse;
 import agilementor.member.entity.Member;
 import agilementor.member.repository.MemberRepository;
 import agilementor.project.dto.request.ProjectInviteRequest;
+import agilementor.project.dto.response.ProejctMemberResponse;
 import agilementor.project.entity.Invitation;
 import agilementor.project.entity.Project;
 import agilementor.project.entity.ProjectMember;
@@ -38,7 +38,7 @@ public class ProjectMemberService {
         this.invitationRepository = invitationRepository;
     }
 
-    public List<MemberGetResponse> getProjectMemberList(Long memberId, Long projectId) {
+    public List<ProejctMemberResponse> getProjectMemberList(Long memberId, Long projectId) {
 
         List<ProjectMember> projectMemberList = projectMemberRepository.findByProjectId(projectId);
 
@@ -50,7 +50,7 @@ public class ProjectMemberService {
         }
 
         return projectMemberList.stream()
-            .map(projectMember -> MemberGetResponse.from(projectMember.getMember()))
+            .map(ProejctMemberResponse::from)
             .toList();
     }
 

--- a/backend/src/main/java/agilementor/project/service/ProjectService.java
+++ b/backend/src/main/java/agilementor/project/service/ProjectService.java
@@ -52,9 +52,7 @@ public class ProjectService {
 
     public ProjectResponse getProject(Long memberId, Long projectId) {
 
-        ProjectMember projectMember = projectMemberRepository
-            .findByMemberIdAndProjectId(memberId, projectId)
-            .orElseThrow(ProjectNotFoundException::new);
+        ProjectMember projectMember = getProjectMember(memberId, projectId);
 
         return ProjectResponse.from(projectMember.getProject());
     }
@@ -78,9 +76,7 @@ public class ProjectService {
     public ProjectResponse updateProject(Long memberId, Long projectId,
         ProjectUpdateRequest projectUpdateRequest) {
 
-        ProjectMember projectMember = projectMemberRepository
-            .findByMemberIdAndProjectId(memberId, projectId)
-            .orElseThrow(ProjectNotFoundException::new);
+        ProjectMember projectMember = getProjectMember(memberId, projectId);
 
         if (projectMember.isNotAdmin()) {
             throw new NotProjectAdminException();
@@ -93,9 +89,7 @@ public class ProjectService {
 
     public void deleteProject(Long memberId, Long projectId) {
 
-        ProjectMember projectMember = projectMemberRepository
-            .findByMemberIdAndProjectId(memberId, projectId)
-            .orElseThrow(ProjectNotFoundException::new);
+        ProjectMember projectMember = getProjectMember(memberId, projectId);
 
         if (projectMember.isNotAdmin()) {
             throw new NotProjectAdminException();
@@ -104,5 +98,18 @@ public class ProjectService {
         Project project = projectMember.getProject();
         projectMemberRepository.deleteAllByProject(project);
         projectRespository.delete(project);
+    }
+
+    public void leaveProject(Long memberId, Long projectId) {
+
+        ProjectMember projectMember = getProjectMember(memberId, projectId);
+
+        projectMemberRepository.delete(projectMember);
+    }
+
+    private ProjectMember getProjectMember(Long memberId, Long projectId) {
+        return projectMemberRepository
+            .findByMemberIdAndProjectId(memberId, projectId)
+            .orElseThrow(ProjectNotFoundException::new);
     }
 }

--- a/backend/src/main/java/agilementor/project/service/ProjectService.java
+++ b/backend/src/main/java/agilementor/project/service/ProjectService.java
@@ -36,7 +36,7 @@ public class ProjectService {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(MemberNotFoundException::new);
         Project project = projectRespository.save(projectCreateRequest.toEntity());
-        projectMemberRepository.save(new ProjectMember(project, member));
+        projectMemberRepository.save(new ProjectMember(project, member, true));
 
         return ProjectResponse.from(project);
     }

--- a/backend/src/main/java/agilementor/project/service/ProjectService.java
+++ b/backend/src/main/java/agilementor/project/service/ProjectService.java
@@ -3,7 +3,6 @@ package agilementor.project.service;
 import agilementor.common.exception.MemberNotFoundException;
 import agilementor.common.exception.NotProjectAdminException;
 import agilementor.common.exception.ProjectNotFoundException;
-import agilementor.member.dto.response.MemberGetResponse;
 import agilementor.member.entity.Member;
 import agilementor.member.repository.MemberRepository;
 import agilementor.project.dto.request.ProjectCreateRequest;
@@ -55,22 +54,6 @@ public class ProjectService {
         ProjectMember projectMember = getProjectMember(memberId, projectId);
 
         return ProjectResponse.from(projectMember.getProject());
-    }
-
-    public List<MemberGetResponse> getProjectMemberList(Long memberId, Long projectId) {
-
-        List<ProjectMember> projectMemberList = projectMemberRepository.findByProjectId(projectId);
-
-        boolean isNotMemberOfProject = projectMemberList.stream()
-            .noneMatch(projectMember -> projectMember.getMember().getMemberId().equals(memberId));
-
-        if (isNotMemberOfProject) {
-            throw new ProjectNotFoundException();
-        }
-
-        return projectMemberList.stream()
-            .map(projectMember -> MemberGetResponse.from(projectMember.getMember()))
-            .toList();
     }
 
     public ProjectResponse updateProject(Long memberId, Long projectId,

--- a/backend/src/main/java/agilementor/project/service/ProjectService.java
+++ b/backend/src/main/java/agilementor/project/service/ProjectService.java
@@ -1,6 +1,7 @@
 package agilementor.project.service;
 
 import agilementor.common.exception.MemberNotFoundException;
+import agilementor.common.exception.NotProjectAdminException;
 import agilementor.common.exception.ProjectNotFoundException;
 import agilementor.member.dto.response.MemberGetResponse;
 import agilementor.member.entity.Member;
@@ -81,7 +82,9 @@ public class ProjectService {
             .findByMemberIdAndProjectId(memberId, projectId)
             .orElseThrow(ProjectNotFoundException::new);
 
-        // todo: 프로젝트 수정 권한 있는지 확인
+        if (projectMember.isNotAdmin()) {
+            throw new NotProjectAdminException();
+        }
 
         Project project = projectMember.getProject();
         project.update(projectUpdateRequest.title());
@@ -94,7 +97,9 @@ public class ProjectService {
             .findByMemberIdAndProjectId(memberId, projectId)
             .orElseThrow(ProjectNotFoundException::new);
 
-        // todo: 프로젝트 삭제 권한 있는지 확인
+        if (projectMember.isNotAdmin()) {
+            throw new NotProjectAdminException();
+        }
 
         Project project = projectMember.getProject();
         projectMemberRepository.deleteAllByProject(project);

--- a/backend/src/test/java/agilementor/project/service/InvitationServiceTest.java
+++ b/backend/src/test/java/agilementor/project/service/InvitationServiceTest.java
@@ -1,0 +1,61 @@
+package agilementor.project.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import agilementor.member.entity.Member;
+import agilementor.project.dto.response.InvitationGetResponse;
+import agilementor.project.entity.Invitation;
+import agilementor.project.entity.Project;
+import agilementor.project.repository.InvitationRepository;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class InvitationServiceTest {
+
+    @Mock
+    private InvitationRepository invitationRepository;
+
+    @InjectMocks
+    private InvitationService invitationService;
+
+    @Test
+    @DisplayName("초대 목록을 조회할 수 있다.")
+    void getInvitationList() {
+        // given
+        Long invitationId = 1L;
+        Long inviteeId = 1L;
+        String projectTitle = "프로젝트";
+        String invitorName = "초대자";
+
+        Project project = new Project(projectTitle);
+        Member invitor = new Member("invitor@email.com", invitorName, "pic.jpg");
+        Member invitee = new Member("invitee@email.com", "피초대자", "pic.jpg");
+        Invitation invitation = new Invitation(project, invitee, invitor);
+        ReflectionTestUtils.setField(invitation, "invitationId", invitationId);
+
+        given(invitationRepository.findByInviteeId(inviteeId))
+            .willReturn(List.of(invitation));
+
+        // when
+        List<InvitationGetResponse> invitationList = invitationService.getInvitationList(inviteeId);
+
+        // then
+        assertThat(invitationList.size()).isEqualTo(1);
+
+        InvitationGetResponse invitationGetResponse = invitationList.getFirst();
+        assertThat(invitationGetResponse.invitationId()).isEqualTo(invitationId);
+        assertThat(invitationGetResponse.projectTitle()).isEqualTo(projectTitle);
+        assertThat(invitationGetResponse.invitorName()).isEqualTo(invitorName);
+    }
+}

--- a/backend/src/test/java/agilementor/project/service/InvitationServiceTest.java
+++ b/backend/src/test/java/agilementor/project/service/InvitationServiceTest.java
@@ -123,4 +123,63 @@ class InvitationServiceTest {
         assertThatThrownBy(() -> invitationService.acceptInvitation(loginMemberId, invitationId))
             .isInstanceOf(InvalidInvitationException.class);
     }
+
+    @Test
+    @DisplayName("초대를 거절할 수 있다.")
+    void declineInvitation() {
+        // given
+        Long invitationId = 1L;
+        Long inviteeId = 1L;
+
+        Project project = new Project("title");
+        Member invitor = new Member("invitor@email.com", "invitor", "pic.jpg");
+        Member invitee = new Member("invitee@email.com", "피초대자", "pic.jpg");
+        ReflectionTestUtils.setField(invitee, "memberId", inviteeId);
+        Invitation invitation = new Invitation(project, invitee, invitor);
+
+        given(invitationRepository.findById(invitationId)).willReturn(Optional.of(invitation));
+
+        // when
+        invitationService.declineInvitation(inviteeId, invitationId);
+
+        // then
+        then(invitationRepository).should().delete(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 id의 초대를 거절할 수 없다.")
+    void declineInvitationFailIfNotExisting() {
+        // given
+        Long invitationId = 1L;
+        Long inviteeId = 1L;
+
+        given(invitationRepository.findById(invitationId)).willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> invitationService.declineInvitation(inviteeId, invitationId))
+            .isInstanceOf(InvalidInvitationException.class);
+    }
+
+    @Test
+    @DisplayName("자신이 초대 대상이 아닌 초대를 거절할 수 없다.")
+    void declineInvitationFailIfNotInvitee() {
+        // given
+        Long invitationId = 1L;
+        Long inviteeId = 1L;
+        Long loginMemberId = 2L;
+
+        Project project = new Project("title");
+        Member invitor = new Member("invitor@email.com", "invitor", "pic.jpg");
+        Member invitee = new Member("invitee@email.com", "피초대자", "pic.jpg");
+        ReflectionTestUtils.setField(invitee, "memberId", inviteeId);
+        Invitation invitation = new Invitation(project, invitee, invitor);
+
+        given(invitationRepository.findById(invitationId)).willReturn(Optional.of(invitation));
+
+        // when
+        // then
+        assertThatThrownBy(() -> invitationService.declineInvitation(loginMemberId, invitationId))
+            .isInstanceOf(InvalidInvitationException.class);
+    }
 }

--- a/backend/src/test/java/agilementor/project/service/ProjectMemberServiceTest.java
+++ b/backend/src/test/java/agilementor/project/service/ProjectMemberServiceTest.java
@@ -185,7 +185,9 @@ class ProjectMemberServiceTest {
 
         List<ProjectMember> projectMemberList = createProjectMemberList();
         Member targetMember = new Member(OTHER_MEMBER_EMAIL, "새 회원", "pic.jpg");
+        Member invitor = new Member("admin@email.com", "관리자", "pic.jpg");
         ReflectionTestUtils.setField(targetMember, "memberId", OTHER_MEMBER_ID);
+        ReflectionTestUtils.setField(invitor, "memberId", ADMIN_MEMBER_ID);
         Project project = new Project("title");
 
         given(projectMemberRepository.findByProjectId(PROJECT_ID)).willReturn(projectMemberList);
@@ -193,8 +195,10 @@ class ProjectMemberServiceTest {
             .willReturn(Optional.of(targetMember));
         given(projectRespository.findById(PROJECT_ID))
             .willReturn(Optional.of(project));
-        given(invitationRepository.existsByMemberAndProject(targetMember, project))
+        given(invitationRepository.existsByProjectAndInvitee(project, targetMember))
             .willReturn(false);
+        given(memberRepository.findById(ADMIN_MEMBER_ID))
+            .willReturn(Optional.of(invitor));
 
         // when
         projectMemberService.inviteMember(ADMIN_MEMBER_ID, PROJECT_ID, inviteRequest);
@@ -289,7 +293,7 @@ class ProjectMemberServiceTest {
             .willReturn(Optional.of(targetMember));
         given(projectRespository.findById(PROJECT_ID))
             .willReturn(Optional.of(project));
-        given(invitationRepository.existsByMemberAndProject(targetMember, project))
+        given(invitationRepository.existsByProjectAndInvitee(project, targetMember))
             .willReturn(true);
 
         // When

--- a/backend/src/test/java/agilementor/project/service/ProjectMemberServiceTest.java
+++ b/backend/src/test/java/agilementor/project/service/ProjectMemberServiceTest.java
@@ -1,0 +1,101 @@
+package agilementor.project.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import agilementor.common.exception.ProjectNotFoundException;
+import agilementor.member.dto.response.MemberGetResponse;
+import agilementor.member.entity.Member;
+import agilementor.project.entity.Project;
+import agilementor.project.entity.ProjectMember;
+import agilementor.project.repository.ProjectMemberRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectMemberServiceTest {
+
+    @Mock
+    private ProjectMemberRepository projectMemberRepository;
+
+    @InjectMocks
+    private ProjectMemberService projectMemberService;
+
+    @Test
+    @DisplayName("프로젝트에 참가한 회원 목록을 조회할 수 있다.")
+    void getProjectMemberList() {
+        // given
+        Long memberId = 1L;
+        Member member1 = new Member("email1@email.com", "name", "pic.jpg");
+        Member member2 = new Member("email2@email.com", "name", "pic.jpg");
+        Member member3 = new Member("email3@email.com", "name", "pic.jpg");
+        Project project = new Project("project");
+        ProjectMember projectMember1 = new ProjectMember(project, member1, true);
+        ProjectMember projectMember2 = new ProjectMember(project, member2, false);
+        ProjectMember projectMember3 = new ProjectMember(project, member3, false);
+        List<ProjectMember> projectMemberList = List.of(projectMember1, projectMember2,
+            projectMember3);
+
+        ReflectionTestUtils.setField(member1, "memberId", memberId);
+        ReflectionTestUtils.setField(member2, "memberId", memberId + 1);
+        ReflectionTestUtils.setField(member3, "memberId", memberId + 2);
+
+        given(projectMemberRepository.findByProjectId(any())).willReturn(projectMemberList);
+
+        // when
+        List<MemberGetResponse> actual = projectMemberService.getProjectMemberList(memberId, 1L);
+
+        // then
+        assertThat(actual.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 프로젝트의 회원 목록은 조회할 수 없다.")
+    void getProjectMemberListFailIfNotExisting() {
+        // given
+        List<ProjectMember> projectMemberList = List.of();
+
+        given(projectMemberRepository.findByProjectId(any())).willReturn(projectMemberList);
+
+        // when
+        // then
+        assertThatThrownBy(() -> projectMemberService.getProjectMemberList(1L, 1L))
+            .isInstanceOf(ProjectNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("참가하지 않은 프로젝트의 회원 목록은 조회할 수 없다.")
+    void getProjectMemberListFailIfNotParticipating() {
+        // given
+        Long memberId = 1L;
+        Long otherMemberId = 100L;
+        Member member1 = new Member("email1@email.com", "name", "pic.jpg");
+        Member member2 = new Member("email2@email.com", "name", "pic.jpg");
+        Member member3 = new Member("email3@email.com", "name", "pic.jpg");
+        Project project = new Project("project");
+        ProjectMember projectMember1 = new ProjectMember(project, member1, true);
+        ProjectMember projectMember2 = new ProjectMember(project, member2, false);
+        ProjectMember projectMember3 = new ProjectMember(project, member3, false);
+        List<ProjectMember> projectMemberList = List.of(projectMember1, projectMember2,
+            projectMember3);
+
+        ReflectionTestUtils.setField(member1, "memberId", memberId);
+        ReflectionTestUtils.setField(member2, "memberId", memberId + 1);
+        ReflectionTestUtils.setField(member3, "memberId", memberId + 2);
+
+        given(projectMemberRepository.findByProjectId(any())).willReturn(projectMemberList);
+
+        // when
+        // then
+        assertThatThrownBy(() -> projectMemberService.getProjectMemberList(otherMemberId, 1L))
+            .isInstanceOf(ProjectNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/agilementor/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/agilementor/project/service/ProjectServiceTest.java
@@ -68,7 +68,7 @@ class ProjectServiceTest {
     @DisplayName("참가한 프로젝트 목록을 조회할 수 있다.")
     void getProjectList() {
         // given
-        Member member = new Member("email@email.com", "name", "pic.jpg");
+        Member member = getMember();
         Project project1 = new Project("project1");
         Project project2 = new Project("project2");
         ProjectMember projectMember1 = new ProjectMember(project1, member, true);
@@ -89,7 +89,7 @@ class ProjectServiceTest {
     void getProject() {
         // given
         String projectTitle = "title";
-        Member member = new Member("email@email.com", "name", "pic.jpg");
+        Member member = getMember();
         Project project = new Project(projectTitle);
         ProjectMember projectMember = new ProjectMember(project, member, true);
 
@@ -205,7 +205,7 @@ class ProjectServiceTest {
         // given
         String title = "title";
         String newTitle = "newTitle";
-        Member member = new Member("email@email.com", "name", "pic.jpg");
+        Member member = getMember();
         Project project = new Project(title);
         ProjectMember projectMember = new ProjectMember(project, member, true);
         ProjectUpdateRequest projectUpdateRequest = new ProjectUpdateRequest(newTitle);
@@ -254,7 +254,7 @@ class ProjectServiceTest {
         // given
         String title = "title";
         String newTitle = "newTitle";
-        Member member = new Member("email@email.com", "name", "pic.jpg");
+        Member member = getMember();
         Project project = new Project(title);
         ProjectMember projectMember = new ProjectMember(project, member, false);
         ProjectUpdateRequest projectUpdateRequest = new ProjectUpdateRequest(newTitle);
@@ -272,7 +272,7 @@ class ProjectServiceTest {
     @DisplayName("프로젝트를 삭제할 수 있다")
     void deleteProject() {
         // given
-        Member member = new Member("email@email.com", "name", "pic.jpg");
+        Member member = getMember();
         Project project = new Project("title");
         ProjectMember projectMember = new ProjectMember(project, member, true);
 
@@ -317,7 +317,7 @@ class ProjectServiceTest {
     @DisplayName("관리자 권한이 없는 프로젝트를 삭제할 수 없다.")
     void deleteProjectFailIfNotAdmin() {
         // given
-        Member member = new Member("email@email.com", "name", "pic.jpg");
+        Member member = getMember();
         Project project = new Project("title");
         ProjectMember projectMember = new ProjectMember(project, member, false);
 
@@ -328,6 +328,37 @@ class ProjectServiceTest {
         // then
         assertThatThrownBy(() -> projectService.deleteProject(1L, 1L))
             .isInstanceOf(NotProjectAdminException.class);
+    }
+
+    @Test
+    @DisplayName("프로젝트에서 나갈 수 있다.")
+    void leaveProject() {
+        // given
+        Member member = getMember();
+        Project project = new Project("title");
+        ProjectMember projectMember = new ProjectMember(project, member, true);
+
+        given(projectMemberRepository.findByMemberIdAndProjectId(any(), any()))
+            .willReturn(Optional.of(projectMember));
+
+        // when
+        projectService.leaveProject(1L, 1L);
+
+        // then
+        then(projectMemberRepository).should().delete(projectMember);
+    }
+
+    @Test
+    @DisplayName("참가하지 않은 프로젝트에서는 나갈 수 없다.")
+    void leaveProjectFailIfNotParticipating() {
+        // given
+        given(projectMemberRepository.findByMemberIdAndProjectId(any(), any()))
+            .willReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> projectService.leaveProject(1L, 1L))
+            .isInstanceOf(ProjectNotFoundException.class);
     }
 
     private static Member getMember() {

--- a/backend/src/test/java/agilementor/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/agilementor/project/service/ProjectServiceTest.java
@@ -70,8 +70,8 @@ class ProjectServiceTest {
         Member member = new Member("email@email.com", "name", "pic.jpg");
         Project project1 = new Project("project1");
         Project project2 = new Project("project2");
-        ProjectMember projectMember1 = new ProjectMember(project1, member);
-        ProjectMember projectMember2 = new ProjectMember(project2, member);
+        ProjectMember projectMember1 = new ProjectMember(project1, member, true);
+        ProjectMember projectMember2 = new ProjectMember(project2, member, true);
         List<ProjectMember> projectMemberList = List.of(projectMember1, projectMember2);
 
         given(projectMemberRepository.findByMemberId(any())).willReturn(projectMemberList);
@@ -90,7 +90,7 @@ class ProjectServiceTest {
         String projectTitle = "title";
         Member member = new Member("email@email.com", "name", "pic.jpg");
         Project project = new Project(projectTitle);
-        ProjectMember projectMember = new ProjectMember(project, member);
+        ProjectMember projectMember = new ProjectMember(project, member, true);
 
         given(projectMemberRepository.findByMemberIdAndProjectId(any(), any()))
             .willReturn(Optional.of(projectMember));
@@ -137,9 +137,9 @@ class ProjectServiceTest {
         Member member2 = new Member("email2@email.com", "name", "pic.jpg");
         Member member3 = new Member("email3@email.com", "name", "pic.jpg");
         Project project = new Project("project");
-        ProjectMember projectMember1 = new ProjectMember(project, member1);
-        ProjectMember projectMember2 = new ProjectMember(project, member2);
-        ProjectMember projectMember3 = new ProjectMember(project, member3);
+        ProjectMember projectMember1 = new ProjectMember(project, member1, true);
+        ProjectMember projectMember2 = new ProjectMember(project, member2, false);
+        ProjectMember projectMember3 = new ProjectMember(project, member3, false);
         List<ProjectMember> projectMemberList = List.of(projectMember1, projectMember2,
             projectMember3);
 
@@ -180,9 +180,9 @@ class ProjectServiceTest {
         Member member2 = new Member("email2@email.com", "name", "pic.jpg");
         Member member3 = new Member("email3@email.com", "name", "pic.jpg");
         Project project = new Project("project");
-        ProjectMember projectMember1 = new ProjectMember(project, member1);
-        ProjectMember projectMember2 = new ProjectMember(project, member2);
-        ProjectMember projectMember3 = new ProjectMember(project, member3);
+        ProjectMember projectMember1 = new ProjectMember(project, member1, true);
+        ProjectMember projectMember2 = new ProjectMember(project, member2, false);
+        ProjectMember projectMember3 = new ProjectMember(project, member3, false);
         List<ProjectMember> projectMemberList = List.of(projectMember1, projectMember2,
             projectMember3);
 
@@ -206,7 +206,7 @@ class ProjectServiceTest {
         String newTitle = "newTitle";
         Member member = new Member("email@email.com", "name", "pic.jpg");
         Project project = new Project(title);
-        ProjectMember projectMember = new ProjectMember(project, member);
+        ProjectMember projectMember = new ProjectMember(project, member, true);
         ProjectUpdateRequest projectUpdateRequest = new ProjectUpdateRequest(newTitle);
 
         given(projectMemberRepository.findByMemberIdAndProjectId(any(), any()))
@@ -259,7 +259,7 @@ class ProjectServiceTest {
         // given
         Member member = new Member("email@email.com", "name", "pic.jpg");
         Project project = new Project("title");
-        ProjectMember projectMember = new ProjectMember(project, member);
+        ProjectMember projectMember = new ProjectMember(project, member, true);
 
         given(projectMemberRepository.findByMemberIdAndProjectId(any(), any()))
             .willReturn(Optional.of(projectMember));

--- a/backend/src/test/java/agilementor/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/agilementor/project/service/ProjectServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import agilementor.common.exception.NotProjectAdminException;
 import agilementor.common.exception.ProjectNotFoundException;
 import agilementor.member.dto.response.MemberGetResponse;
 import agilementor.member.entity.Member;
@@ -250,7 +251,21 @@ class ProjectServiceTest {
     @Test
     @DisplayName("관리자 권한이 없는 프로젝트 정보를 수정할 수 없다.")
     void updateProjectFailIfNotAdmin() {
-        // todo: 권한 체크 기능 테스트 추가
+        // given
+        String title = "title";
+        String newTitle = "newTitle";
+        Member member = new Member("email@email.com", "name", "pic.jpg");
+        Project project = new Project(title);
+        ProjectMember projectMember = new ProjectMember(project, member, false);
+        ProjectUpdateRequest projectUpdateRequest = new ProjectUpdateRequest(newTitle);
+
+        given(projectMemberRepository.findByMemberIdAndProjectId(any(), any()))
+            .willReturn(Optional.of(projectMember));
+
+        // when
+        // then
+        assertThatThrownBy(() -> projectService.updateProject(1L, 1L, projectUpdateRequest))
+            .isInstanceOf(NotProjectAdminException.class);
     }
 
     @Test
@@ -301,7 +316,18 @@ class ProjectServiceTest {
     @Test
     @DisplayName("관리자 권한이 없는 프로젝트를 삭제할 수 없다.")
     void deleteProjectFailIfNotAdmin() {
-        // todo: 권한 체크 기능 테스트 추가
+        // given
+        Member member = new Member("email@email.com", "name", "pic.jpg");
+        Project project = new Project("title");
+        ProjectMember projectMember = new ProjectMember(project, member, false);
+
+        given(projectMemberRepository.findByMemberIdAndProjectId(any(), any()))
+            .willReturn(Optional.of(projectMember));
+
+        // when
+        // then
+        assertThatThrownBy(() -> projectService.deleteProject(1L, 1L))
+            .isInstanceOf(NotProjectAdminException.class);
     }
 
     private static Member getMember() {

--- a/backend/src/test/java/agilementor/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/agilementor/project/service/ProjectServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.BDDMockito.then;
 
 import agilementor.common.exception.NotProjectAdminException;
 import agilementor.common.exception.ProjectNotFoundException;
-import agilementor.member.dto.response.MemberGetResponse;
 import agilementor.member.entity.Member;
 import agilementor.member.repository.MemberRepository;
 import agilementor.project.dto.request.ProjectCreateRequest;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectServiceTest {
@@ -126,76 +124,6 @@ class ProjectServiceTest {
         // when
         // then
         assertThatThrownBy(() -> projectService.getProject(1L, 1L))
-            .isInstanceOf(ProjectNotFoundException.class);
-    }
-
-    @Test
-    @DisplayName("프로젝트에 참가한 회원 목록을 조회할 수 있다.")
-    void getProjectMemberList() {
-        // given
-        Long memberId = 1L;
-        Member member1 = new Member("email1@email.com", "name", "pic.jpg");
-        Member member2 = new Member("email2@email.com", "name", "pic.jpg");
-        Member member3 = new Member("email3@email.com", "name", "pic.jpg");
-        Project project = new Project("project");
-        ProjectMember projectMember1 = new ProjectMember(project, member1, true);
-        ProjectMember projectMember2 = new ProjectMember(project, member2, false);
-        ProjectMember projectMember3 = new ProjectMember(project, member3, false);
-        List<ProjectMember> projectMemberList = List.of(projectMember1, projectMember2,
-            projectMember3);
-
-        ReflectionTestUtils.setField(member1, "memberId", memberId);
-        ReflectionTestUtils.setField(member2, "memberId", memberId + 1);
-        ReflectionTestUtils.setField(member3, "memberId", memberId + 2);
-
-        given(projectMemberRepository.findByProjectId(any())).willReturn(projectMemberList);
-
-        // when
-        List<MemberGetResponse> actual = projectService.getProjectMemberList(memberId, 1L);
-
-        // then
-        assertThat(actual.size()).isEqualTo(3);
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 프로젝트의 회원 목록은 조회할 수 없다.")
-    void getProjectMemberListFailIfNotExisting() {
-        // given
-        List<ProjectMember> projectMemberList = List.of();
-
-        given(projectMemberRepository.findByProjectId(any())).willReturn(projectMemberList);
-
-        // when
-        // then
-        assertThatThrownBy(() -> projectService.getProjectMemberList(1L, 1L))
-            .isInstanceOf(ProjectNotFoundException.class);
-    }
-
-    @Test
-    @DisplayName("참가하지 않은 프로젝트의 회원 목록은 조회할 수 없다.")
-    void getProjectMemberListFailIfNotParticipating() {
-        // given
-        Long memberId = 1L;
-        Long otherMemberId = 100L;
-        Member member1 = new Member("email1@email.com", "name", "pic.jpg");
-        Member member2 = new Member("email2@email.com", "name", "pic.jpg");
-        Member member3 = new Member("email3@email.com", "name", "pic.jpg");
-        Project project = new Project("project");
-        ProjectMember projectMember1 = new ProjectMember(project, member1, true);
-        ProjectMember projectMember2 = new ProjectMember(project, member2, false);
-        ProjectMember projectMember3 = new ProjectMember(project, member3, false);
-        List<ProjectMember> projectMemberList = List.of(projectMember1, projectMember2,
-            projectMember3);
-
-        ReflectionTestUtils.setField(member1, "memberId", memberId);
-        ReflectionTestUtils.setField(member2, "memberId", memberId + 1);
-        ReflectionTestUtils.setField(member3, "memberId", memberId + 2);
-
-        given(projectMemberRepository.findByProjectId(any())).willReturn(projectMemberList);
-
-        // when
-        // then
-        assertThatThrownBy(() -> projectService.getProjectMemberList(otherMemberId, 1L))
             .isInstanceOf(ProjectNotFoundException.class);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
#47 [FEAT] 프로젝트 회원 관리 기능 구현

## ✨ PR 내용
프로젝트 회원 초대, 추방, 탈퇴 기능과 자신에게 온 초대 목록 조회, 초대 수락, 초대 거절 기능을 구현했습니다.
프로젝트 관리자 여부를 추가하고, 초대 및 추방시 관리자 권한 확인 로직을 추가했습니다.

## 📸 스크린샷(선택)
