### PR TITLE
[FEAT] 회원 본인 정보 조회 기능 구현

### DIFF
--- a/backend/src/main/java/agilementor/member/controller/MemberController.java
+++ b/backend/src/main/java/agilementor/member/controller/MemberController.java
@@ -1,0 +1,25 @@
+package agilementor.member.controller;
+
+import agilementor.member.dto.response.MemberGetResponse;
+import agilementor.member.service.MemberService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+@RestController
+@RequestMapping("/api/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @GetMapping
+    public MemberGetResponse getLoginMemberInfo(@SessionAttribute("memberId") Long memberId) {
+
+        return memberService.getMember(memberId);
+    }
+}

--- a/backend/src/main/java/agilementor/member/dto/response/MemberGetResponse.java
+++ b/backend/src/main/java/agilementor/member/dto/response/MemberGetResponse.java
@@ -4,11 +4,13 @@ import agilementor.member.entity.Member;
 
 public record MemberGetResponse(
     Long memberId,
+    String email,
     String name,
     String picture
 ) {
 
     public static MemberGetResponse from(Member member) {
-        return new MemberGetResponse(member.getMemberId(), member.getName(), member.getPicture());
+        return new MemberGetResponse(member.getMemberId(), member.getEmail(), member.getName(),
+            member.getPicture());
     }
 }

--- a/backend/src/main/java/agilementor/member/service/MemberService.java
+++ b/backend/src/main/java/agilementor/member/service/MemberService.java
@@ -1,6 +1,8 @@
 package agilementor.member.service;
 
+import agilementor.common.exception.MemberNotFoundException;
 import agilementor.member.dto.ParsedIdToken;
+import agilementor.member.dto.response.MemberGetResponse;
 import agilementor.member.entity.Member;
 import agilementor.member.repository.MemberRepository;
 import agilementor.member.util.JwtParser;
@@ -28,5 +30,11 @@ public class MemberService {
         member.update(parsedIdToken.toEntity());
 
         return member.getMemberId();
+    }
+
+    public MemberGetResponse getMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(MemberNotFoundException::new);
+        return MemberGetResponse.from(member);
     }
 }

--- a/backend/src/test/java/agilementor/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/agilementor/member/service/MemberServiceTest.java
@@ -1,21 +1,23 @@
 package agilementor.member.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import agilementor.member.dto.ParsedIdToken;
+import agilementor.member.dto.response.MemberGetResponse;
 import agilementor.member.entity.Member;
 import agilementor.member.repository.MemberRepository;
 import agilementor.member.util.JwtParser;
 import java.util.Optional;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -58,9 +60,33 @@ class MemberServiceTest {
         memberService.registerOrUpdateMember("token");
 
         // then
-        Assertions.assertThat(member.getEmail()).isEqualTo(parsedIdToken.email());
-        Assertions.assertThat(member.getName()).isEqualTo(parsedIdToken.name());
-        Assertions.assertThat(member.getPicture()).isEqualTo(parsedIdToken.picture());
+        assertThat(member.getEmail()).isEqualTo(parsedIdToken.email());
+        assertThat(member.getName()).isEqualTo(parsedIdToken.name());
+        assertThat(member.getPicture()).isEqualTo(parsedIdToken.picture());
+    }
+
+    @Test
+    @DisplayName("회원 정보를 확인할 수 있다.")
+    void getMember() {
+        // given
+        Long memberId = 1L;
+        String email = "testEmail@agilementor.kr";
+        String name = "이름";
+        String picture = "https://test.agilementor.kr/pic.jpg";
+
+        Member member = new Member(email, name, picture);
+        ReflectionTestUtils.setField(member, "memberId", memberId);
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        // when
+        MemberGetResponse memberGetResponse = memberService.getMember(memberId);
+
+        // then
+        assertThat(memberGetResponse.memberId()).isEqualTo(memberId);
+        assertThat(memberGetResponse.email()).isEqualTo(email);
+        assertThat(memberGetResponse.name()).isEqualTo(name);
+        assertThat(memberGetResponse.picture()).isEqualTo(picture);
     }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
#57 [FEAT] 로그인한 회원 본인 정보 조회 기능 구현

## ✨ PR 내용
이전에 커밋 실수로 사라져버린 로그인한 회원 본인 정보를 조회하는 API를 다시 구현했습니다.

## 📸 스크린샷(선택)
