### PR TITLE
[FEAT] 네비게이트 메뉴 활성화

### DIFF
--- a/frontend/src/components/common/NavigateMenu/index.jsx
+++ b/frontend/src/components/common/NavigateMenu/index.jsx
@@ -1,28 +1,33 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { FaRunning, FaThList, FaBook, FaChartLine } from 'react-icons/fa';
 
-const NavigateMenu = () => (
-  <Container>
-    <Title>이용하기</Title>
-    <MenuItem>
-      <Icon as={FaRunning} />
-      <MenuText>백로그 및 스프린트</MenuText>
-    </MenuItem>
-    <MenuItem>
-      <Icon as={FaThList} />
-      <MenuText>칸반보드</MenuText>
-    </MenuItem>
-    <MenuItem>
-      <Icon as={FaBook} />
-      <MenuText>애자일 학습하기</MenuText>
-    </MenuItem>
-    <MenuItem>
-      <Icon as={FaChartLine} />
-      <MenuText>번다운 차트</MenuText>
-    </MenuItem>
-  </Container>
-);
+const NavigateMenu = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Container>
+      <Title>이용하기</Title>
+      <MenuItem onClick={() => navigate('/backlogandsprint')}>
+        <Icon as={FaRunning} />
+        <MenuText>백로그 및 스프린트</MenuText>
+      </MenuItem>
+      <MenuItem onClick={() => navigate('/kanbanboard')}>
+        <Icon as={FaThList} />
+        <MenuText>칸반보드</MenuText>
+      </MenuItem>
+      <MenuItem>
+        <Icon as={FaBook} />
+        <MenuText>애자일 학습하기</MenuText>
+      </MenuItem>
+      <MenuItem onClick={() => navigate('/burndown')}>
+        <Icon as={FaChartLine} />
+        <MenuText>번다운 차트</MenuText>
+      </MenuItem>
+    </Container>
+  );
+};
 
 export default NavigateMenu;
 

--- a/frontend/src/components/features/SideBar.jsx
+++ b/frontend/src/components/features/SideBar.jsx
@@ -15,10 +15,12 @@ import LogoutButton from '@components/common/LogoutButton';
 import Member from '@components/common/Member';
 // eslint-disable-next-line import/no-unresolved
 import SettingButton from '@components/common/SettingButton';
+import { useNavigate } from 'react-router-dom';
 import { useProjects } from '../../provider/projectContext';
 
 const SideBar = () => {
   const { setProjects, projects } = useProjects();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchProjects = async () => {
@@ -57,7 +59,7 @@ const SideBar = () => {
       <SelectProjectWrapper>
         <SelectProject projects={projects} />
       </SelectProjectWrapper>
-      <DashboardLink href="#">
+      <DashboardLink onClick={() => navigate('/dashboard')}>
         <IoHomeIcon />
         대시보드
       </DashboardLink>


### PR DESCRIPTION
## 📌 관련 이슈
#64 네비게이트 메뉴 활성화 하기

## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->

### 네비게이션 메뉴 컴포넌트에서 다음 경로로 이동할 수 있도록 활성화했습니다.
- 대시보드 (/dashboard)
- 백로그 및 스프린트 (/backlogandsprint)
- 칸반보드 (/kanbanboard)
- 애자일 학습하기 (/agilelearning)
- 번다운 차트 (/burndown)


## 📸 스크린샷(선택)
![녹화_2024_11_27_14_16_18_350](https://github.com/user-attachments/assets/531f2a44-d30a-4a1d-81d8-24575c8daec4)