### PR TITLE
[FEAT] 멤버 목록 조회, 초대, 추방 API 연결

### DIFF
--- a/frontend/src/components/common/Member/index.jsx
+++ b/frontend/src/components/common/Member/index.jsx
@@ -1,11 +1,16 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { FaCrown } from 'react-icons/fa';
 // eslint-disable-next-line import/no-unresolved
 import MinModal from '@components/common/MinModal';
+import axios from 'axios';
+import { useProjects } from '../../../provider/projectContext';
 
 const Member = ({ members }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [email, setEmail] = useState('');
+  const { selectedProjectId, fetchMembers } = useProjects();
 
   const openModal = () => {
     setIsModalOpen(true);
@@ -13,6 +18,52 @@ const Member = ({ members }) => {
 
   const closeModal = () => {
     setIsModalOpen(false);
+    setEmail('');
+  };
+
+  const handleInvite = async () => {
+    if (!selectedProjectId) {
+      alert('프로젝트를 선택해주세요.');
+      return;
+    }
+
+    const response = await axios.post(
+      `https://api.agilementor.kr/api/projects/${selectedProjectId}/invitations`,
+      { email },
+      {
+        headers: {
+          Cookie: document.cookie,
+        },
+        withCredentials: true,
+      },
+    );
+
+    if (response.status === 200) {
+      alert('초대가 성공적으로 완료되었습니다.');
+      closeModal();
+    }
+  };
+
+  const handleKick = async (memberId) => {
+    if (!selectedProjectId || !memberId) {
+      alert('프로젝트 또는 멤버 정보가 없습니다.');
+      return;
+    }
+
+    const response = await axios.delete(
+      `https://api.agilementor.kr/api/projects/${selectedProjectId}/members/${memberId}`,
+      {
+        headers: {
+          Cookie: document.cookie,
+        },
+        withCredentials: true,
+      },
+    );
+
+    if (response.status === 204) {
+      alert('멤버가 성공적으로 추방되었습니다.');
+      fetchMembers(selectedProjectId);
+    }
   };
 
   return (
@@ -23,12 +74,23 @@ const Member = ({ members }) => {
       </Header>
       <MemberList>
         {members.map((member) => (
-          <MemberItem key={member.id}>
+          <MemberItem key={member.memberId}>
             <MemberName>
+              <ProfileImage
+                src={member.profileImageUrl}
+                alt={`${member.name}'s profile`}
+                onError={(e) => {
+                  e.target.src = 'https://via.placeholder.com/96';
+                }}
+              />
               {member.name}
               {member.isAdmin && <CrownIcon />}
             </MemberName>
-            {!member.isAdmin && <KickButton>추방</KickButton>}
+            {!member.isAdmin && (
+              <KickButton onClick={() => handleKick(member.memberId)}>
+                추방
+              </KickButton>
+            )}
           </MemberItem>
         ))}
       </MemberList>
@@ -37,8 +99,10 @@ const Member = ({ members }) => {
         <MinModal
           title="초대하기"
           description="초대하실 분의 이메일을 입력해 주세요."
+          type="email"
+          onChange={(e) => setEmail(e.target.value)}
           onCancel={closeModal}
-          onConfirm={closeModal}
+          onConfirm={handleInvite}
         />
       )}
     </Container>
@@ -48,8 +112,9 @@ const Member = ({ members }) => {
 Member.propTypes = {
   members: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.number.isRequired,
+      memberId: PropTypes.number.isRequired,
       name: PropTypes.string.isRequired,
+      profileImageUrl: PropTypes.string,
       isAdmin: PropTypes.bool.isRequired,
     }),
   ).isRequired,
@@ -106,24 +171,17 @@ const MemberName = styled.span`
   color: #333;
   display: flex;
   align-items: center;
-  position: relative;
-  padding-left: 1.2vw;
-
-  &::before {
-    content: '';
-    display: inline-block;
-    width: 0.6vw;
-    height: 0.6vw;
-    background-color: #333;
-    border-radius: 50%;
-    position: absolute;
-    left: 0;
-    top: 50%;
-    transform: translateY(-50%);
-  }
+  gap: 0.5vw;
 `;
 
-const CrownIcon = styled.span`
+const ProfileImage = styled.img`
+  width: 2.4vh;
+  height: 2.4vh;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+const CrownIcon = styled(FaCrown)`
   color: #ffd700;
   margin-left: 0.5vw;
   font-size: 1.6vh;

--- a/frontend/src/components/features/SideBar.jsx
+++ b/frontend/src/components/features/SideBar.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import axios from 'axios';
 import { IoHome } from 'react-icons/io5';
 // eslint-disable-next-line import/no-unresolved
@@ -19,18 +18,23 @@ import { useNavigate } from 'react-router-dom';
 import { useProjects } from '../../provider/projectContext';
 
 const SideBar = () => {
-  const { setProjects, projects } = useProjects();
+  const {
+    setProjects,
+    projects,
+    selectedProjectId,
+    setSelectedProjectId,
+    members,
+    fetchMembers,
+  } = useProjects();
   const navigate = useNavigate();
 
+  // Fetch projects on component mount
   useEffect(() => {
     const fetchProjects = async () => {
       try {
         const response = await axios.get(
           'https://api.agilementor.kr/api/projects',
           {
-            headers: {
-              Cookie: document.cookie,
-            },
             withCredentials: true,
           },
         );
@@ -44,12 +48,15 @@ const SideBar = () => {
     fetchProjects();
   }, [setProjects]);
 
-  const members = [
-    { id: 1, name: '지연우', isAdmin: true },
-    { id: 2, name: '오 탐', isAdmin: false },
-    { id: 3, name: '장현지', isAdmin: false },
-    { id: 4, name: '임지환', isAdmin: false },
-  ];
+  // Fetch members when selectedProjectId changes
+  useEffect(() => {
+    if (selectedProjectId) {
+      fetchMembers(selectedProjectId);
+    } else {
+      // Reset members when no project is selected
+      fetchMembers(null);
+    }
+  }, [selectedProjectId, fetchMembers]);
 
   return (
     <SidebarContainer>
@@ -57,7 +64,10 @@ const SideBar = () => {
         <CreateProjectButton />
       </CreateProjectButtonWrapper>
       <SelectProjectWrapper>
-        <SelectProject projects={projects} />
+        <SelectProject
+          projects={projects}
+          onSelectProject={(projectId) => setSelectedProjectId(projectId)}
+        />
       </SelectProjectWrapper>
       <DashboardLink onClick={() => navigate('/dashboard')}>
         <IoHomeIcon />
@@ -66,9 +76,11 @@ const SideBar = () => {
       <NavigateMenuWrapper>
         <NavigateMenu />
       </NavigateMenuWrapper>
-      <MemberWrapper>
-        <Member members={members} />
-      </MemberWrapper>
+      {selectedProjectId && (
+        <MemberWrapper>
+          <Member members={members} />
+        </MemberWrapper>
+      )}
       <DividerWrapper>
         <SettingButtonWrapper>
           <SettingButton onClick={() => console.log('클릭됨')} />

--- a/frontend/src/provider/projectContext.js
+++ b/frontend/src/provider/projectContext.js
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useCallback } from 'react';
+import axios from 'axios';
 
 const ProjectContext = createContext();
 
@@ -6,11 +7,68 @@ const ProjectContext = createContext();
 export const ProjectProvider = ({ children }) => {
   const [projects, setProjects] = useState([]);
   const [selectedProjectId, setSelectedProjectId] = useState(null);
+  const [sprints, setSprints] = useState([]);
+  const [members, setMembers] = useState([]); // 멤버 데이터를 저장할 상태 추가
+
+  const fetchSprints = async (projectId) => {
+    if (!projectId) {
+      console.warn('프로젝트 ID가 없습니다.');
+      return;
+    }
+
+    try {
+      const response = await axios.get(
+        `https://api.agilementor.kr/api/projects/${projectId}/sprints`,
+        {
+          headers: {
+            Cookie: document.cookie,
+          },
+          withCredentials: true,
+        },
+      );
+      setSprints(response.data);
+    } catch (error) {
+      console.error('스프린트 데이터를 가져오는 중 오류 발생:', error);
+    }
+  };
+
+  const fetchMembers = useCallback(async (projectId) => {
+    if (!projectId) {
+      console.warn('프로젝트 ID가 없습니다.');
+      setMembers([]); // 프로젝트 선택 해제 시 멤버 초기화
+      return;
+    }
+
+    try {
+      const response = await axios.get(
+        `https://api.agilementor.kr/api/projects/${projectId}/members`,
+        {
+          headers: {
+            Cookie: document.cookie,
+          },
+          withCredentials: true,
+        },
+      );
+      setMembers(response.data); // 멤버 데이터를 상태에 저장
+    } catch (error) {
+      console.error('멤버 데이터를 가져오는 중 오류 발생:', error);
+    }
+  }, []); // useCallback으로 메모이제이션
 
   return (
     <ProjectContext.Provider
       // eslint-disable-next-line react/jsx-no-constructed-context-values
-      value={{ projects, setProjects, selectedProjectId, setSelectedProjectId }}
+      value={{
+        projects,
+        setProjects,
+        selectedProjectId,
+        setSelectedProjectId,
+        sprints,
+        setSprints,
+        fetchSprints,
+        members,
+        fetchMembers,
+      }}
     >
       {children}
     </ProjectContext.Provider>


### PR DESCRIPTION
## 📌 관련 이슈
#67 멤버 목록 조회, 초대, 추방 API 연결

## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->
### 프로젝트 멤버 관리 기능 추가
- 선택된 프로젝트에 따라 멤버 데이터를 가져오는 fetchMembers 함수 구현.
- 프로젝트 선택 해제 시 멤버 데이터를 초기화하도록 로직 추가.
- useCallback을 사용해 fetchMembers 함수 메모이제이션 적용.
### 컨텍스트 확장
- sprints, members, fetchSprints, fetchMembers 상태 및 함수 추가.
### 멤버 데이터 초기화 로직 개선
- 프로젝트 선택이 변경될 때 멤버 데이터를 적절히 처리하도록 로직 구현.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
