### PR TITLE
[FIX] 프로젝트 삭제, 탈퇴, 추방시 스프린트,스토리,백로그 처리 로직 추가

### DIFF
--- a/backend/src/main/java/agilementor/backlog/entity/Backlog.java
+++ b/backend/src/main/java/agilementor/backlog/entity/Backlog.java
@@ -111,12 +111,17 @@ public class Backlog {
         this.story = story;
     }
 
-    public void setAssignee(Member assignee) {
-        this.assignee = assignee;
+    public void deleteAssignee() {
+        this.assignee = null;
+        this.status = Status.TODO;
     }
 
     public boolean isDone() {
         return status.equals(Status.DONE);
+    }
+
+    public boolean isNotDone() {
+        return !status.equals(Status.DONE);
     }
 
     public void update(String title, String description, Status status, Priority priority,

--- a/backend/src/main/java/agilementor/backlog/repository/BacklogRepository.java
+++ b/backend/src/main/java/agilementor/backlog/repository/BacklogRepository.java
@@ -24,4 +24,6 @@ public interface BacklogRepository extends JpaRepository<Backlog, Long> {
 
     // 스프린트 ID로 조회하고 상태가 특정 값이 아닌 백로그 반환
     List<Backlog> findBySprint_IdAndStatusNot(Long sprintId, Status status);
+
+    void deleteByProject(Project project);
 }

--- a/backend/src/main/java/agilementor/backlog/repository/BacklogRepository.java
+++ b/backend/src/main/java/agilementor/backlog/repository/BacklogRepository.java
@@ -20,6 +20,8 @@ public interface BacklogRepository extends JpaRepository<Backlog, Long> {
 
     List<Backlog> findByAssigneeAndSprint(Member member, Sprint sprint);
 
+    List<Backlog> findByAssigneeAndProject(Member member, Project project);
+
     Optional<Backlog> findByBacklogIdAndProject(Long backlogId, Project project);
 
     // 스프린트 ID로 조회하고 상태가 특정 값이 아닌 백로그 반환

--- a/backend/src/main/java/agilementor/backlog/repository/StoryRepository.java
+++ b/backend/src/main/java/agilementor/backlog/repository/StoryRepository.java
@@ -11,4 +11,6 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
     List<Story> findByProject(Project project);
 
     Optional<Story> findByStoryIdAndProject(Long storyId, Project project);
+
+    void deleteByProject(Project project);
 }

--- a/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
+++ b/backend/src/main/java/agilementor/project/service/ProjectMemberService.java
@@ -1,5 +1,7 @@
 package agilementor.project.service;
 
+import agilementor.backlog.entity.Backlog;
+import agilementor.backlog.repository.BacklogRepository;
 import agilementor.common.exception.AlreadyJoinedMemberException;
 import agilementor.common.exception.KickOneselfException;
 import agilementor.common.exception.MemberNotFoundException;
@@ -28,14 +30,16 @@ public class ProjectMemberService {
     private final ProjectRespository projectRespository;
     private final ProjectMemberRepository projectMemberRepository;
     private final InvitationRepository invitationRepository;
+    private final BacklogRepository backlogRepository;
 
     public ProjectMemberService(MemberRepository memberRepository,
         ProjectRespository projectRespository, ProjectMemberRepository projectMemberRepository,
-        InvitationRepository invitationRepository) {
+        InvitationRepository invitationRepository, BacklogRepository backlogRepository) {
         this.memberRepository = memberRepository;
         this.projectRespository = projectRespository;
         this.projectMemberRepository = projectMemberRepository;
         this.invitationRepository = invitationRepository;
+        this.backlogRepository = backlogRepository;
     }
 
     public List<ProejctMemberResponse> getProjectMemberList(Long memberId, Long projectId) {
@@ -72,6 +76,14 @@ public class ProjectMemberService {
             .filter(projectMember -> projectMember.getMember().getMemberId().equals(targetMemberId))
             .findFirst()
             .orElseThrow(MemberNotFoundException::new);
+
+        Member member = targetProjectMember.getMember();
+        Project project = targetProjectMember.getProject();
+
+        List<Backlog> backlogList = backlogRepository.findByAssigneeAndProject(member, project);
+        backlogList.stream()
+            .filter(Backlog::isNotDone)
+            .forEach(Backlog::deleteAssignee);
 
         projectMemberRepository.delete(targetProjectMember);
     }

--- a/backend/src/main/java/agilementor/project/service/ProjectService.java
+++ b/backend/src/main/java/agilementor/project/service/ProjectService.java
@@ -1,5 +1,7 @@
 package agilementor.project.service;
 
+import agilementor.backlog.repository.BacklogRepository;
+import agilementor.backlog.repository.StoryRepository;
 import agilementor.common.exception.MemberNotFoundException;
 import agilementor.common.exception.NotProjectAdminException;
 import agilementor.common.exception.ProjectNotFoundException;
@@ -12,6 +14,7 @@ import agilementor.project.entity.Project;
 import agilementor.project.entity.ProjectMember;
 import agilementor.project.repository.ProjectMemberRepository;
 import agilementor.project.repository.ProjectRespository;
+import agilementor.sprint.repository.SprintRepository;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -23,12 +26,19 @@ public class ProjectService {
     private final MemberRepository memberRepository;
     private final ProjectRespository projectRespository;
     private final ProjectMemberRepository projectMemberRepository;
+    private final BacklogRepository backlogRepository;
+    private final StoryRepository storyRepository;
+    private final SprintRepository sprintRepository;
 
     public ProjectService(MemberRepository memberRepository, ProjectRespository projectRespository,
-        ProjectMemberRepository projectMemberRepository) {
+        ProjectMemberRepository projectMemberRepository, BacklogRepository backlogRepository,
+        StoryRepository storyRepository, SprintRepository sprintRepository) {
         this.memberRepository = memberRepository;
         this.projectRespository = projectRespository;
         this.projectMemberRepository = projectMemberRepository;
+        this.backlogRepository = backlogRepository;
+        this.storyRepository = storyRepository;
+        this.sprintRepository = sprintRepository;
     }
 
     public ProjectResponse createProject(Long memberId, ProjectCreateRequest projectCreateRequest) {
@@ -79,6 +89,11 @@ public class ProjectService {
         }
 
         Project project = projectMember.getProject();
+
+        backlogRepository.deleteByProject(project);
+        storyRepository.deleteByProject(project);
+        sprintRepository.deleteByProject(project);
+
         projectMemberRepository.deleteAllByProject(project);
         projectRespository.delete(project);
     }

--- a/backend/src/main/java/agilementor/project/service/ProjectService.java
+++ b/backend/src/main/java/agilementor/project/service/ProjectService.java
@@ -1,5 +1,6 @@
 package agilementor.project.service;
 
+import agilementor.backlog.entity.Backlog;
 import agilementor.backlog.repository.BacklogRepository;
 import agilementor.backlog.repository.StoryRepository;
 import agilementor.common.exception.MemberNotFoundException;
@@ -101,6 +102,14 @@ public class ProjectService {
     public void leaveProject(Long memberId, Long projectId) {
 
         ProjectMember projectMember = getProjectMember(memberId, projectId);
+
+        Member member = projectMember.getMember();
+        Project project = projectMember.getProject();
+
+        List<Backlog> backlogList = backlogRepository.findByAssigneeAndProject(member, project);
+        backlogList.stream()
+            .filter(Backlog::isNotDone)
+            .forEach(Backlog::deleteAssignee);
 
         projectMemberRepository.delete(projectMember);
     }

--- a/backend/src/main/java/agilementor/sprint/repository/SprintRepository.java
+++ b/backend/src/main/java/agilementor/sprint/repository/SprintRepository.java
@@ -23,4 +23,6 @@ public interface SprintRepository extends JpaRepository<Sprint, Long> {
     List<Sprint> findByProject_ProjectIdAndIsDoneFalse(Long projectId);
 
     List<Sprint> findByProject_ProjectIdAndIsDoneTrueOrderByEndDateAsc(Long projectId);
+
+    void deleteByProject(Project project);
 }

--- a/backend/src/test/java/agilementor/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/agilementor/project/service/ProjectServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import agilementor.backlog.repository.BacklogRepository;
+import agilementor.backlog.repository.StoryRepository;
 import agilementor.common.exception.NotProjectAdminException;
 import agilementor.common.exception.ProjectNotFoundException;
 import agilementor.member.entity.Member;
@@ -17,6 +19,7 @@ import agilementor.project.entity.Project;
 import agilementor.project.entity.ProjectMember;
 import agilementor.project.repository.ProjectMemberRepository;
 import agilementor.project.repository.ProjectRespository;
+import agilementor.sprint.repository.SprintRepository;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +40,15 @@ class ProjectServiceTest {
 
     @Mock
     private ProjectMemberRepository projectMemberRepository;
+
+    @Mock
+    private BacklogRepository backlogRepository;
+
+    @Mock
+    private StoryRepository storyRepository;
+
+    @Mock
+    private SprintRepository sprintRepository;
 
     @InjectMocks
     private ProjectService projectService;
@@ -212,6 +224,9 @@ class ProjectServiceTest {
 
         // then
         then(projectMemberRepository).should().deleteAllByProject(project);
+        then(backlogRepository).should().deleteByProject(project);
+        then(storyRepository).should().deleteByProject(project);
+        then(sprintRepository).should().deleteByProject(project);
         then(projectRespository).should().delete(project);
     }
 

--- a/backend/src/test/java/agilementor/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/agilementor/project/service/ProjectServiceTest.java
@@ -6,6 +6,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import agilementor.backlog.entity.Backlog;
+import agilementor.backlog.entity.Priority;
+import agilementor.backlog.entity.Status;
 import agilementor.backlog.repository.BacklogRepository;
 import agilementor.backlog.repository.StoryRepository;
 import agilementor.common.exception.NotProjectAdminException;
@@ -281,14 +284,34 @@ class ProjectServiceTest {
         Project project = new Project("title");
         ProjectMember projectMember = new ProjectMember(project, member, true);
 
+        Backlog backlog1 = new Backlog("backlog1", "backlog1", Priority.MEDIUM, project, null, null,
+            member);
+        Backlog backlog2 = new Backlog("backlog2", "backlog2", Priority.MEDIUM, project, null, null,
+            member);
+        backlog2.update("backlog2", "backlog2", Status.IN_PROGRESS, Priority.MEDIUM, project, null,
+            null, member);
+        Backlog backlog3 = new Backlog("backlog3", "backlog3", Priority.MEDIUM, project, null, null,
+            member);
+        backlog3.update("backlog3", "backlog3", Status.DONE, Priority.MEDIUM, project, null, null,
+            member);
+        List<Backlog> backlogs = List.of(backlog1, backlog2, backlog3);
+
         given(projectMemberRepository.findByMemberIdAndProjectId(any(), any()))
             .willReturn(Optional.of(projectMember));
+        given(backlogRepository.findByAssigneeAndProject(member, project))
+            .willReturn(backlogs);
 
         // when
         projectService.leaveProject(1L, 1L);
 
         // then
         then(projectMemberRepository).should().delete(projectMember);
+        assertThat(backlog1.getStatus()).isEqualTo(Status.TODO);
+        assertThat(backlog1.getAssignee()).isNull();
+        assertThat(backlog2.getStatus()).isEqualTo(Status.TODO);
+        assertThat(backlog2.getAssignee()).isNull();
+        assertThat(backlog3.getStatus()).isEqualTo(Status.DONE);
+        assertThat(backlog3.getAssignee()).isEqualTo(member);
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
#85 [FIX] 프로젝트 삭제, 탈퇴, 추방시 스프린트,스토리,백로그 처리 로직 추가

## ✨ PR 내용
- 하위 스토리, 스프린트, 백로그가 있을 때 프로젝트가 삭제되지 않던 오류 수정
  - 프로젝트 삭제, 탈퇴, 추방시 스토리 및 백로그 처리 로직을 추가
- 프로젝트 탈퇴 및 추방시 해당 사용자에게 배정되었지만 완료되지 않은 모든 백로그들의 상태를 TODO로, 담당자를 null로 수정합니다.

## 📸 스크린샷(선택)
