### PR TITLE
[FIX] 세션 유효기간, cors 설정 변경

### DIFF
--- a/backend/src/main/java/agilementor/common/config/WebConfig.java
+++ b/backend/src/main/java/agilementor/common/config/WebConfig.java
@@ -19,7 +19,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-            .allowedOriginPatterns("*")  // todo: 테스트가 끝나면 https://agilementor.kr로 수정
+            .allowedOriginPatterns("https://agilementor.kr", "https://www.agilementor.kr")
             .allowedMethods("GET", "POST", "PUT", "DELETE")
             .exposedHeaders("Location")
             .maxAge(1800)

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,4 +4,4 @@ spring.profiles.active=oauth,db,chatgpt
 server.servlet.session.tracking-modes=cookie
 server.servlet.session.cookie.secure=true
 server.servlet.session.cookie.same-site=none
-server.servlet.session.timeout=1800
+server.servlet.session.timeout=3600


### PR DESCRIPTION
## 📌 관련 이슈
#114 [FIX] 세션 유효기간, cors 설정 변경

## ✨ PR 내용
- 세션 유효기간 1800초(30분) -> 3600초(1시간) 로 수정
- CORS 설정의 allowOrigin을 배포 url로 설정

## 📸 스크린샷(선택)
